### PR TITLE
Add Tasks.seqActions(...) to sequence actions

### DIFF
--- a/src/com/linkedin/parseq/SeqActionsTask.java
+++ b/src/com/linkedin/parseq/SeqActionsTask.java
@@ -1,0 +1,89 @@
+package com.linkedin.parseq;
+
+import com.linkedin.parseq.internal.InternalUtil;
+import com.linkedin.parseq.promise.Promise;
+import com.linkedin.parseq.promise.PromiseListener;
+import com.linkedin.parseq.promise.Promises;
+import com.linkedin.parseq.promise.SettablePromise;
+import com.linkedin.parseq.trace.ShallowTrace;
+import com.linkedin.parseq.trace.ShallowTraceBuilder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author Chris Pettitt
+ */
+/* package private */ class SeqActionsTask extends BaseTask<Void>
+{
+  private final List<Task<Object>> _tasks;
+
+  public SeqActionsTask(final String name, final Iterable<? extends Task<?>> tasks)
+  {
+    super(name);
+    List<Task<Object>> taskList = new ArrayList<Task<Object>>();
+    for(Task<?> task : tasks)
+    {
+      taskList.add(InternalUtil.unwildcardTask(task));
+    }
+
+    if (taskList.size() == 0)
+    {
+      throw new IllegalArgumentException("No tasks to sequence!");
+    }
+
+    _tasks = Collections.unmodifiableList(taskList);
+  }
+
+  @Override
+  protected Promise<Void> run(final Context context) throws Exception
+  {
+    final SettablePromise<Void> result = Promises.settable();
+    final AtomicInteger count = new AtomicInteger(_tasks.size());
+    final PromiseListener<Object> listener = new PromiseListener<Object>()
+    {
+      @Override
+      public void onResolved(final Promise<Object> promise)
+      {
+        if (promise.isFailed())
+        {
+          if (count.get() > 0) {
+            count.set(0);
+            result.fail(promise.getError());
+          }
+        }
+        else
+        {
+          if (count.decrementAndGet() == 0)
+          {
+            result.done(null);
+          }
+        }
+      }
+    };
+
+    Task<Object> prevTask = _tasks.get(0);
+    prevTask.addListener(listener);
+    for (int i = 1; i < _tasks.size(); i++)
+    {
+      final Task<Object> currTask = _tasks.get(i);
+      currTask.addListener(listener);
+      context.after(prevTask).run(currTask);
+      prevTask = currTask;
+    }
+
+    context.run(_tasks.get(0));
+    return result;
+  }
+
+  @Override
+  public ShallowTrace getShallowTrace()
+  {
+    ShallowTrace shallowTrace = super.getShallowTrace();
+    ShallowTraceBuilder builder = new ShallowTraceBuilder(shallowTrace);
+    builder.setSystemHidden(true);
+    return builder.build();
+  }
+}

--- a/src/com/linkedin/parseq/Tasks.java
+++ b/src/com/linkedin/parseq/Tasks.java
@@ -197,6 +197,30 @@ public class Tasks
   }
 
   /**
+   * Creates a new task that will run each of the supplied tasks in order. If
+   * any of the tasks in the sequence fail then the whole sequence will be marked
+   * as failed and no subsequent tasks will be executed. This method is
+   * appropriate for a chain of actions that produce no data. When the sequence
+   * should return a result, use {@link #seq(Task, Task)}.
+   */
+  public static Task<Void> seqActions(final Task... tasks)
+  {
+    return new SeqActionsTask("seqActions", Arrays.<Task<?>>asList(tasks));
+  }
+
+  /**
+   * Creates a new task that will run each of the supplied tasks in order. If
+   * any of the tasks in the sequence fail then the whole sequence will be marked
+   * as failed and no subsequent tasks will be executed. This method is
+   * appropriate for a chain of actions that produce no data. When the sequence
+   * should return a result, use {@link #seq(Task, Task)}.
+   */
+  public static Task<Void> seqActions(final Iterable<? extends Task<?>> tasks)
+  {
+    return new SeqActionsTask("seqActions", tasks);
+  }
+
+  /**
    * Creates a new task that will run the given tasks in parallel (e.g. task1
    * can be executed at the same time as task2). When all tasks complete
    * successfully, you can use {@link com.linkedin.parseq.ParTask#get()} to

--- a/test/com/linkedin/parseq/TestSeqActionsTask.java
+++ b/test/com/linkedin/parseq/TestSeqActionsTask.java
@@ -1,0 +1,88 @@
+package com.linkedin.parseq;
+
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.linkedin.parseq.Tasks.seqActions;
+import static com.linkedin.parseq.TestUtil.noop;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.AssertJUnit.fail;
+
+/**
+ * @author Chris Pettitt
+ */
+public class TestSeqActionsTask extends BaseEngineTest
+{
+  @Test
+  public void testWithEmptyList()
+  {
+    try
+    {
+      seqActions();
+      fail("Should have thrown IllegalArgumentException");
+    }
+    catch (IllegalArgumentException e)
+    {
+      // Expected case
+    }
+  }
+
+  @Test
+  public void testWithSequenceOfActions() throws InterruptedException
+  {
+    final int numTasks = 10;
+    final AtomicInteger counter = new AtomicInteger();
+    final List<Task<?>> tasks = new ArrayList<Task<?>>();
+    for (int i = 0; i < numTasks; ++i)
+    {
+      final int finalI = i;
+      tasks.add(Tasks.action("action-" + i, new Runnable()
+      {
+        @Override
+        public void run()
+        {
+          final int count = counter.getAndIncrement();
+          assertEquals("Tasks executed out of order!", count, finalI);
+        }
+      }));
+    }
+
+    final Task<Void> seq = Tasks.seqActions(tasks);
+    getEngine().run(seq);
+
+    seq.await();
+
+    assertNull(seq.get());
+    assertEquals("Task count does not match counter", counter.get(), numTasks);
+  }
+
+  @Test
+  public void testWithFailureMidSequence() throws InterruptedException
+  {
+    final RuntimeException exception = new RuntimeException();
+    final Task<Void> throwingTask = Tasks.action("throwing task", new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        throw exception;
+      }
+    });
+
+    final Task<?> lastTask = noop();
+    final Task<Void> seq = Tasks.seqActions(noop(), throwingTask, lastTask);
+    getEngine().run(seq);
+
+    seq.await();
+
+    assertTrue(seq.isFailed());
+    assertEquals(exception, seq.getError());
+    assertTrue(lastTask.isFailed());
+    assertTrue(lastTask.getError() instanceof EarlyFinishException);
+  }
+}


### PR DESCRIPTION
@cheftako @sweeboonlim @chikit @brikis98 

This new task makes it easy to sequence a set of actions when you don't
need the result from the last task. Our current Tasks.seq(...) tasks
return the value of the last task. When recursively sequencing fan out
(parallel tasks) this can lead to a List<List<...List<T>...>> type for
the seq task when subsequent aggregation does not occur.

The behavior of seqActions differs from seq in that any task that fails
in the sequence causes the sequence to terminate immediately with an
error.
