### PR TITLE
Use slf4j-api to replace slf4j-log4j12 in build dependency.

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -19,7 +19,8 @@
     <dependencies>
         <dependency org="org.codehaus.jackson" name="jackson-core-asl" rev="1.4.2" conf="build->default"/>
         <dependency org="org.codehaus.jackson" name="jackson-mapper-asl" rev="1.4.2" conf="build->default"/>
-        <dependency org="org.slf4j" name="slf4j-log4j12" rev="1.5.6" conf="build->default"/>
+        <dependency org="org.slf4j" name="slf4j-api" rev="1.6.2" conf="build->default"/>
         <dependency org="org.testng" name="testng" rev="6.4" conf="bootstrap->default; test->default"/>
+        <dependency org="org.slf4j" name="slf4j-log4j12" rev="1.6.2" conf="test->default"/>
     </dependencies>
 </ivy-module>

--- a/test/com/linkedin/parseq/ListLogger.java
+++ b/test/com/linkedin/parseq/ListLogger.java
@@ -255,7 +255,7 @@ public class ListLogger extends MarkerIgnoringBase
   {
     if (isLevelEnabled(level))
     {
-      final String msg = MessageFormatter.format(s, o);
+      final String msg = MessageFormatter.format(s, o).getMessage();
       _entries.add(new Entry(level, msg));
     }
   }
@@ -265,7 +265,7 @@ public class ListLogger extends MarkerIgnoringBase
   {
     if (isLevelEnabled(level))
     {
-      final String msg = MessageFormatter.format(s, o, o1);
+      final String msg = MessageFormatter.format(s, o, o1).getMessage();
       _entries.add(new Entry(level, msg));
     }
   }
@@ -274,7 +274,7 @@ public class ListLogger extends MarkerIgnoringBase
   {
     if (isLevelEnabled(level))
     {
-      final String msg = MessageFormatter.arrayFormat(s, objects);
+      final String msg = MessageFormatter.arrayFormat(s, objects).getMessage();
       _entries.add(new Entry(level, msg));
     }
   }


### PR DESCRIPTION
Use slf4j-api to replace slf4j-log4j12 in build dependency.
Bump slf4j to 1.6.2.

I locally tested on pegasus and verified all tests pass.
