### PR TITLE
Added AsyncCallableTaskWithSLA and tests

### DIFF
--- a/src/com/linkedin/parseq/AsyncCallableTaskWithSLA.java
+++ b/src/com/linkedin/parseq/AsyncCallableTaskWithSLA.java
@@ -1,0 +1,183 @@
+package com.linkedin.parseq;
+
+
+import com.linkedin.parseq.BaseTask;
+import com.linkedin.parseq.Context;
+import com.linkedin.parseq.EngineBuilder;
+import com.linkedin.parseq.Tasks;
+import com.linkedin.parseq.promise.Promise;
+import com.linkedin.parseq.promise.Promises;
+import com.linkedin.parseq.promise.SettablePromise;
+import java.lang.IllegalStateException;import java.lang.Override;import java.lang.Runnable;import java.lang.String;import java.lang.Throwable;import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+
+
+/**
+ * Calls a synchronous task in a separate thread to make it asynchronous.  Supports SLA via a timeout in Milliseconds.  Returns a default value on timeout or error.
+ * To use this class three methods may be overridden.  The first method, <code>doTask</code> must be overridden and the second two, <code>onError</code> and <code>onTimeout</code> may be optionally overridden.
+ * <ul>
+ * <li>doTask</li> does the work that is expected to return a result.
+ * <li>onError</li> is called if doTask throws an exception.  If it returns successfully, the promise will succeed with the result, otherwise the promise will fail.
+ * <li>onTimeout</li> is called if doTask takes longer than timeoutInMillis ms to complete.  If it returns successfully, the promise will succeed with the result, otherwise the promise will fail.
+ * </ul>
+ * The <code>taskState</code> property indicates the state of the task (one of <code>{UNDEFINED,SUCCESS,TIMEDOUT,ERROR_ON_TIMEOUT,ERROR,ERROR_ON_ERROR}</code>).
+ * If an error occurs during task processing, it saved in the <code>primaryError</code> property.  If an error occurs while
+ * calling <code>onError</code> or <code>onTimeout</code>, it saved in the <code>secondaryError</code> property.
+ *
+ * @author Eric Melz (emelz@linkedin.com)
+ */
+public abstract class AsyncCallableTaskWithSLA<A> extends BaseTask<A>
+{
+  private final long _timeoutInMillis;
+  public static final String CALLABLE_SERVICE_EXECUTOR = "_CallableServiceExecutor_";
+  private Throwable _primaryError;
+  private Throwable _secondaryError;
+  private TaskState _taskState;
+
+  public Throwable getPrimaryError()
+  {
+    return _primaryError;
+  }
+
+  public Throwable getSecondaryError()
+  {
+    return _secondaryError;
+  }
+
+  public TaskState getTaskState()
+  {
+    return _taskState;
+  }
+
+  public AsyncCallableTaskWithSLA(long timeoutInMillis)
+  {
+    super();
+    _timeoutInMillis = timeoutInMillis;
+    _taskState = TaskState.UNDEFINED;
+  }
+
+  enum TaskState {
+    UNDEFINED,
+    SUCCESS,
+    TIMEDOUT,
+    ERROR_ON_TIMEOUT,
+    ERROR,
+    ERROR_ON_ERROR
+  }
+
+  public static void register(EngineBuilder builder, Executor executor)
+  {
+    builder.setEngineProperty(CALLABLE_SERVICE_EXECUTOR, executor);
+  }
+
+  @Override
+  protected Promise<? extends A> run(final Context context) throws Throwable
+  {
+    Executor executor = (Executor)context.getEngineProperty(CALLABLE_SERVICE_EXECUTOR);
+
+    if (executor == null)
+    {
+      throw new IllegalStateException("To use this AsyncCallableTask you must first register an executor with the engine using AsyncCallableTask.register");
+    }
+
+    final SettablePromise<A> promise = Promises.settable();
+    executor.execute(new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        try
+        {
+          A result = doTask();
+          _taskState = TaskState.SUCCESS;
+          promise.done(result);
+        }
+        catch (Throwable t)
+        {
+          A onErrorResult = null;
+          try
+          {
+            _taskState = TaskState.ERROR;
+            _primaryError = t;
+            onErrorResult = onError();
+
+          } catch (Throwable t2)
+          {
+            _taskState = TaskState.ERROR_ON_ERROR;
+            _secondaryError = t2;
+          }
+          if (onErrorResult == null)
+          {
+            if (!promise.isDone())
+            {
+              promise.fail(null);
+            }
+          }
+          else
+          {
+            if (!promise.isDone())
+            {
+              promise.done(onErrorResult);
+            }
+          }
+        }
+      }
+    });
+
+    context.createTimer(_timeoutInMillis, TimeUnit.MILLISECONDS, Tasks.action("timeout", new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        A onTimeoutResult = null;
+        try
+        {
+          _taskState = TaskState.TIMEDOUT;
+          onTimeoutResult = onTimeout();
+
+        }
+        catch (Throwable e)
+        {
+          _secondaryError = e;
+          _taskState = TaskState.ERROR_ON_TIMEOUT;
+        }
+        if (onTimeoutResult == null)
+        {
+          promise.fail(null);
+        }
+        else
+        {
+          promise.done(onTimeout());
+        }
+      }
+    }));
+
+    return promise;
+  }
+
+  /**
+   * Do the actual work of the task.  This will be called in a separate thread.
+   * @return
+   */
+  abstract protected A doTask();
+
+  /**
+   * Do some action if an error occurs during doTask.  If a non-null value is returned, the promise is marked done
+   * with the returned value.  If a null value is returned, or an exception occurs, the promise is failed.
+   * @return default value when an error occurs
+   */
+  protected A onError()
+  {
+    return null;
+  }
+
+  /**
+   * Do some action if a timeout occurs during doTask.  If a non-null value is returned, the promise is marked done
+   * with the returned value.  If a null value is returned, or an exception occurs, the promise is failed.
+   * @return default value when an error occurs
+   */
+  protected A onTimeout()
+  {
+    return null;
+  }
+}

--- a/test/com/linkedin/parseq/BaseEngineTest.java
+++ b/test/com/linkedin/parseq/BaseEngineTest.java
@@ -49,6 +49,7 @@ public class BaseEngineTest
         .setTimerScheduler(_scheduler)
         .setLoggerFactory(_loggerFactory);
     AsyncCallableTask.register(engineBuilder, _asyncExecutor);
+    AsyncCallableTaskWithSLA.register(engineBuilder, _asyncExecutor);
     _engine = engineBuilder.build();
   }
 

--- a/test/com/linkedin/parseq/TestAsyncCallableTaskWithSLA.java
+++ b/test/com/linkedin/parseq/TestAsyncCallableTaskWithSLA.java
@@ -1,0 +1,255 @@
+package com.linkedin.parseq;
+
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static com.linkedin.parseq.AsyncCallableTaskWithSLA.TaskState.*;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.AssertJUnit.assertEquals;
+
+
+/**
+ * @author emelz
+ */
+public class TestAsyncCallableTaskWithSLA extends BaseEngineTest
+{
+  private static final int SHORT_TIMEOUT_IN_MS = 200;
+  private static final int LONG_TIMEOUT_IN_MS = 1000;
+  private static final String DID_SOME_WORK = "Did some work: ";
+  public static final String CUSTOM_TIMEOUT = "Custom timeout!";
+  public static final String THROWING_AN_ERROR = "Throwing an error!";
+  public static final String CUSTOM_ERROR = "Custom error!";
+  public static final String A_SPECIAL_MESSAGE = "A special message";
+  public static final String THROWING_ERROR_ON_TIMEOUT = "Throwing Error on timeout!";
+  public static final String THROWING_ERROR_ON_ERROR = "Throwing Error on error!";
+
+  // Do about 500ms worth of work
+  private String doMyWork(String specialMessage, boolean throwError) {
+    try
+    {
+      Thread.sleep(500);
+    }
+    catch (InterruptedException e)
+    {
+//      e.printStackTrace();
+    }
+    if (throwError)
+    {
+      throw new RuntimeException(THROWING_AN_ERROR);
+    }
+    return DID_SOME_WORK + specialMessage;
+  }
+
+  /**
+   * Create a task that just overrides the work method.  Timeout and error throwing are configurable.
+   * @param timeoutInMs
+   * @param throwAnError
+   * @return
+   */
+  private AsyncCallableTaskWithSLA<String> makeBasicTask(int timeoutInMs, final boolean throwAnError)
+  {
+
+    return new AsyncCallableTaskWithSLA<String>(timeoutInMs)
+    {
+      private String _specialMessage = A_SPECIAL_MESSAGE;
+
+      @Override
+      protected String doTask()
+      {
+        return doMyWork(_specialMessage, throwAnError);
+      }
+    };
+  }
+
+  /**
+   * Create a task that overrides onTimeout() in addition to the work method.  Timeout and error throwing are configurable.
+   * @param timeoutInMs
+   * @param throwAnError
+   * @return
+   */
+  private AsyncCallableTaskWithSLA<String> makeTaskWithCustomTimeout(int timeoutInMs, final boolean throwAnError)
+  {
+
+    return new AsyncCallableTaskWithSLA<String>(timeoutInMs)
+    {
+      private String _specialMessage = A_SPECIAL_MESSAGE;
+
+      @Override
+      protected String doTask()
+      {
+        return doMyWork(_specialMessage, throwAnError);
+      }
+
+      @Override
+      protected String onTimeout()
+      {
+        return CUSTOM_TIMEOUT;
+      }
+    };
+  }
+
+  /**
+   * Create a task that overrides onError() in addition to the work method.  Timeout and error throwing are configurable.
+   * @param timeoutInMs
+   * @param throwAnError
+   * @return
+   */
+  private AsyncCallableTaskWithSLA<String> makeTaskWithCustomError(int timeoutInMs, final boolean throwAnError)
+  {
+
+    return new AsyncCallableTaskWithSLA<String>(timeoutInMs)
+    {
+      private String _specialMessage = A_SPECIAL_MESSAGE;
+
+      @Override
+      protected String doTask()
+      {
+        return doMyWork(_specialMessage, throwAnError);
+      }
+
+      @Override
+      protected String onError()
+      {
+        return CUSTOM_ERROR;
+      }
+    };
+  }
+
+  private AsyncCallableTaskWithSLA<String> makeTaskWithErrorOnTimeout(int timeoutInMs, final boolean throwAnError)
+  {
+
+    return new AsyncCallableTaskWithSLA<String>(timeoutInMs)
+    {
+      private String _specialMessage = A_SPECIAL_MESSAGE;
+
+      @Override
+      protected String doTask()
+      {
+        return doMyWork(_specialMessage, throwAnError);
+      }
+
+      @Override
+      protected String onTimeout()
+      {
+        throw new RuntimeException(THROWING_ERROR_ON_TIMEOUT);
+      }
+    };
+  }
+
+  private AsyncCallableTaskWithSLA<String> makeTaskWithErrorOnError(int timeoutInMs, final boolean throwAnError)
+  {
+
+    return new AsyncCallableTaskWithSLA<String>(timeoutInMs)
+    {
+      private String _specialMessage = A_SPECIAL_MESSAGE;
+
+      @Override
+      protected String doTask()
+      {
+        return doMyWork(_specialMessage, throwAnError);
+      }
+
+      @Override
+      protected String onError()
+      {
+        throw new RuntimeException(THROWING_ERROR_ON_ERROR);
+      }
+    };
+  }
+
+
+
+  @Test
+  public void testSuccess() throws InterruptedException
+  {
+    AsyncCallableTaskWithSLA<String> task = makeBasicTask(LONG_TIMEOUT_IN_MS, false);
+    getEngine().run(task);
+    task.await();
+    String result = task.get();
+    assertEquals(DID_SOME_WORK + A_SPECIAL_MESSAGE, result);
+    assertEquals(SUCCESS, task.getTaskState());
+  }
+
+  @Test
+  public void testDefaultTimeout() throws InterruptedException
+  {
+    AsyncCallableTaskWithSLA<String> task = makeBasicTask(SHORT_TIMEOUT_IN_MS, false);
+    getEngine().run(task);
+    task.await();
+    String result = task.get();
+    assertNull(result);
+    assertEquals(TIMEDOUT, task.getTaskState());
+  }
+
+  @Test
+  public void testCustomTimeout() throws InterruptedException
+  {
+    AsyncCallableTaskWithSLA<String> task = makeTaskWithCustomTimeout(SHORT_TIMEOUT_IN_MS, false);
+    getEngine().run(task);
+    task.await();
+    String result = task.get();
+
+    Assert.assertEquals(CUSTOM_TIMEOUT, result);
+    Assert.assertEquals(TIMEDOUT, task.getTaskState());
+  }
+
+  @Test
+  public void testDefaultError() throws InterruptedException
+  {
+    AsyncCallableTaskWithSLA<String> task = makeBasicTask(LONG_TIMEOUT_IN_MS, true);
+    getEngine().run(task);
+    task.await();
+    String result = task.get();
+    assertNull(result);
+    assertEquals(ERROR, task.getTaskState());
+    assertNotNull(task.getPrimaryError());
+    assertEquals(THROWING_AN_ERROR, task.getPrimaryError().getMessage());
+  }
+
+  @Test
+  public void testCustomError() throws InterruptedException
+  {
+    AsyncCallableTaskWithSLA<String> task = makeTaskWithCustomError(LONG_TIMEOUT_IN_MS, true);
+    getEngine().run(task);
+    task.await();
+    String result = task.get();
+    assertEquals(CUSTOM_ERROR, result);
+    assertEquals(ERROR, task.getTaskState());
+    assertNotNull(task.getPrimaryError());
+    assertEquals(THROWING_AN_ERROR, task.getPrimaryError().getMessage());
+  }
+
+  @Test
+  public void testErrorOnTimeout()
+      throws InterruptedException
+  {
+    AsyncCallableTaskWithSLA<String> task = makeTaskWithErrorOnTimeout(SHORT_TIMEOUT_IN_MS, true);
+    getEngine().run(task);
+    task.await();
+    String result = task.get();
+    assertNull(result);
+    assertEquals(ERROR_ON_TIMEOUT, task.getTaskState());
+    assertNull(task.getPrimaryError());
+    assertNotNull(task.getSecondaryError());
+    assertEquals(THROWING_ERROR_ON_TIMEOUT, task.getSecondaryError().getMessage());
+  }
+
+  @Test
+  public void testErrorOnError()
+      throws InterruptedException
+  {
+    AsyncCallableTaskWithSLA<String> task = makeTaskWithErrorOnError(LONG_TIMEOUT_IN_MS, true);
+    getEngine().run(task);
+    task.await();
+    String result = task.get();
+    assertNull(result);
+    assertEquals(ERROR_ON_ERROR, task.getTaskState());
+    assertNotNull(task.getPrimaryError());
+    assertEquals(THROWING_AN_ERROR, task.getPrimaryError().getMessage());
+    assertNotNull(task.getSecondaryError());
+    Assert.assertEquals(THROWING_ERROR_ON_ERROR, task.getSecondaryError().getMessage());
+  }
+
+}


### PR DESCRIPTION
Adds a new class, AsyncCallableTaskWithSLA.

This is similar to AsyncCallableTask but adds a few new features:
(1) accepts a timeout in a constructor which will timeout the task if it doesn't complete in time
(2) Adds optional onTimeout() and onError() methods, so that a Promise can return special values for these conditions
(3) Adds state variables so that clients can tell what happened to the task, i.e., whether it timed-out, errored, errored on timeout, etc.
(4) Saves exceptions in the cases where the task had errors.  There are two levels of exceptions, primary and secondary.

The class is designed to be easy to use (i.e., users don't need to implement onTimeout and onError, and can ignore status variables if they so choose).

A unit test demos the various use cases.
