### PR TITLE
Changed priorities of tasks scheduled by TimeoutWithErrorTask

### DIFF
--- a/test/com/linkedin/parseq/TestTasks.java
+++ b/test/com/linkedin/parseq/TestTasks.java
@@ -16,21 +16,28 @@
 
 package com.linkedin.parseq;
 
-import com.linkedin.parseq.promise.Promise;
-import com.linkedin.parseq.promise.PromiseListener;
-import com.linkedin.parseq.promise.Promises;
-import org.testng.annotations.Test;
-
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicReference;
-
 import static com.linkedin.parseq.TestUtil.value;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.AssertJUnit.fail;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.testng.annotations.Test;
+
+import com.linkedin.parseq.promise.Promise;
+import com.linkedin.parseq.promise.PromiseListener;
+import com.linkedin.parseq.promise.Promises;
+import com.linkedin.parseq.promise.SettablePromise;
 
 /**
  * @author Chris Pettitt (cpettitt@linkedin.com)
@@ -169,6 +176,52 @@ public class TestTasks extends BaseEngineTest
 
     assertTrue(timeoutTask.isFailed());
     assertEquals(error, timeoutTask.getError());
+  }
+
+  /**
+   * Test scenario in which there are many TimeoutWithErrorTasks scheduled for execution
+   * e.g. by using Tasks.par().
+   */
+  @Test
+  public void testManyTimeoutTaskWithoutTimeoutOnAQueeu() throws InterruptedException, IOException
+  {
+    final String value = "value";
+    final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
+    List<Task<String>> tasks = new ArrayList<Task<String>>();
+    for (int i = 0; i < 50; i++) {
+
+      // Task which simulates doing something for 0.5ms and setting response
+      // asynchronously after 5ms.
+      Task<String> t = new BaseTask<String>("test") {
+        @Override
+        protected Promise<? extends String> run(Context context) throws Throwable {
+          final SettablePromise<String> result = Promises.settable();
+          Thread.sleep(0, 500000);
+          scheduler.schedule(new Runnable() {
+            @Override
+            public void run() {
+              result.done(value);
+            }
+          }, 5, TimeUnit.MILLISECONDS);
+          return result;
+        }
+      };
+      // add 50ms timeout for the task
+      tasks.add(Tasks.timeoutWithError(50, TimeUnit.MILLISECONDS, t));
+    }
+
+    // final task runs all the tasks in parallel
+    final Task<?> timeoutTask = Tasks.par(tasks);
+
+    getEngine().run(timeoutTask);
+
+    assertTrue(timeoutTask.await(5, TimeUnit.SECONDS));
+
+    scheduler.shutdown();
+
+    //tasks should not time out
+    assertEquals(false, timeoutTask.isFailed());
   }
 
   @Test


### PR DESCRIPTION
The problem is described in SI-1658. You can find there traces attached, which demonstrate behavior before and after change of priorities in TimeoutWithErrorTask. Basic idea is to make execution of task which is being wrapped by TimeoutWithErrorTask right after timeout as been scheduled for it. One way of achieving it is to put it on top of the SerialExecutor's priority queue. I considered other options but couldn't find any nice solution without serious refactoring.
