### PR TITLE
[parseq-23] add seq() convenience method for list of Tasks plus a single Task

### DIFF
--- a/src/com/linkedin/parseq/Tasks.java
+++ b/src/com/linkedin/parseq/Tasks.java
@@ -214,6 +214,38 @@ public class Tasks
   }
 
   /**
+   * Creates a new task that, when run, will run each of the supplied tasks in
+   * order, plus an additional task. The value of this new task is value of the last task in the
+   * sequence. <strong>This method is not type-safe</strong>.
+   *
+   * @param tasks the tasks to run sequentially
+   * @param task1 the last task to run
+   * @param <T> the result value for the sequence of tasks
+   * @return a new task that will run the given tasks sequentially
+   */
+  public static <T> Task<T> seq(final Iterable<? extends Task<?>> tasks, Task<?> task1)
+  {
+    final List<Task<T>> taskList = getTypedTaskList(tasks);
+    @SuppressWarnings("unchecked")
+    final Task<T> typedTask = (Task<T>) task1;
+    taskList.add(typedTask);
+
+    return new SeqTask<T>("seq", taskList);
+  }
+
+  private static <T> List<Task<T>> getTypedTaskList(Iterable<? extends Task<?>> tasks)
+  {
+    final List<Task<T>> taskList = new ArrayList<Task<T>>();
+    for (Task<?> task : tasks)
+    {
+      @SuppressWarnings("unchecked")
+      final Task<T> typedTask = (Task<T>) task;
+      taskList.add(typedTask);
+    }
+    return taskList;
+  }
+
+  /**
    * Creates a new task that will run the given tasks in parallel (e.g. task1
    * can be executed at the same time as task2). When all tasks complete
    * successfully, you can use {@link com.linkedin.parseq.ParTask#get()} to

--- a/test/com/linkedin/parseq/TestSeqTask.java
+++ b/test/com/linkedin/parseq/TestSeqTask.java
@@ -81,15 +81,22 @@ public class TestSeqTask extends BaseEngineTest
 
     final Task<Integer> seq = seq(Arrays.asList(tasks));
     getEngine().run(seq);
-
     assertTrue(seq.await(5, TimeUnit.SECONDS));
-
     assertEquals(iters, (int)seq.get());
+  }
+
+  @Test
+  public void testIterablePlusSingleton() throws InterruptedException
+  {
+    final Task<?>[] tasks = new Task<?>[] { value(1), value(2) };
+    final Task<?> seq = seq(Arrays.asList(tasks), value("result"));
+    getEngine().run(seq);
+    assertTrue(seq.await(5, TimeUnit.SECONDS));
+    assertEquals("result", seq.get());
   }
 
   // For following testSeqX() tests, we verify that we can use different types
   // for the last element and the rest of the list.
-
   @Test
   public void testSeq2() throws InterruptedException
   {


### PR DESCRIPTION
[parseq-23] add seq() convenience method for list of Tasks plus a single Task
