### PR TITLE
Add Tasks.value for making tasks that trivially return a value.

### DIFF
--- a/src/com/linkedin/parseq/Tasks.java
+++ b/src/com/linkedin/parseq/Tasks.java
@@ -64,6 +64,20 @@ public class Tasks
   }
 
   /**
+   * Creates a new {@link Task} that just returns the supplied parameter.
+   * This can be useful when returning a fixed value for cases when
+   * a Task is required in general, but the task just returns
+   * a simple value in some instances.
+   *
+   * @param value the value to be returned
+   * @return the new task
+   */
+  public static <T> Task<T> value(String name, final T value)
+  {
+    return new ValueTask<T>(name, value);
+  }
+
+  /**
    * Creates a new {@link Task} that's value will be set to the value returned
    * from the supplied callable. This task is useful when doing basic
    * computation that does not require asynchrony. It is not appropriate for

--- a/src/com/linkedin/parseq/ValueTask.java
+++ b/src/com/linkedin/parseq/ValueTask.java
@@ -1,0 +1,25 @@
+package com.linkedin.parseq;
+
+import com.linkedin.parseq.promise.Promise;
+import com.linkedin.parseq.promise.Promises;
+
+/**
+ * A {@link Task} that returns a value known before the task
+ * itself is instantiated.
+ * <p/>
+ * Use {@link Tasks#value} to create instances of this class.
+ */
+/* package private */ class ValueTask<T> extends BaseTask<T> {
+
+  private final T _value;
+
+  ValueTask(String name, T value) {
+    super(name);
+    _value = value;
+  }
+
+  @Override
+  protected Promise<? extends T> run(Context context) throws Throwable {
+    return Promises.value(_value);
+  }
+}

--- a/test/com/linkedin/parseq/TestUtil.java
+++ b/test/com/linkedin/parseq/TestUtil.java
@@ -79,7 +79,7 @@ public class TestUtil
 
   public static <T> Task<T> value(final String name, final T value)
   {
-    return new ValueTask<T>(name, value);
+    return Tasks.value(name, value);
   }
 
   public static void withDisabledLogging(final Runnable r)
@@ -95,23 +95,6 @@ public class TestUtil
     finally
     {
       loggerRepo.setThreshold(oldLevel);
-    }
-  }
-
-  private static class ValueTask<T> extends BaseTask<T>
-  {
-    private final T _value;
-
-    public ValueTask(final String name, final T value)
-    {
-      super(name);
-      _value = value;
-    }
-
-    @Override
-    protected Promise<? extends T> run(final Context context) throws Exception
-    {
-      return Promises.value(_value);
     }
   }
 }


### PR DESCRIPTION
ValueTask appears to be in the test code. I need something like this, and right now I'm having to use Tasks.callable("...", new Callable() { Whatever call() { return value; }); all over the place (actually, a wrapper around that).

I'd like to suggest this change to move it somewhere accessible.  I can provide some examples within LinkedIn source where I think this is a useful thing to do.