### PR TITLE
Tasks.<T>par(emptyIterable<? extends Task<? extends T>>) should not throw IllegalArgumentException

### DIFF
--- a/src/com/linkedin/parseq/ParTaskImpl.java
+++ b/src/com/linkedin/parseq/ParTaskImpl.java
@@ -23,8 +23,6 @@ import com.linkedin.parseq.promise.PromiseListener;
 import com.linkedin.parseq.promise.Promises;
 import com.linkedin.parseq.promise.SettablePromise;
 import com.linkedin.parseq.trace.ResultType;
-import com.linkedin.parseq.trace.ShallowTrace;
-import com.linkedin.parseq.trace.ShallowTraceBuilder;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -55,11 +53,6 @@ import java.util.List;
       taskList.add(coercedTask);
     }
 
-    if (taskList.isEmpty())
-    {
-      throw new IllegalArgumentException("No tasks to parallelize!");
-    }
-
     _tasks = Collections.unmodifiableList(taskList);
 
   }
@@ -68,6 +61,11 @@ import java.util.List;
   protected Promise<List<T>> run(final Context context) throws Exception
   {
     final SettablePromise<List<T>> result = Promises.settable();
+    if(_tasks.isEmpty())
+    {
+      result.done(Collections.<T>emptyList());
+      return result;
+    }
 
     final PromiseListener<?> listener = new PromiseListener<Object>()
     {

--- a/test/com/linkedin/parseq/TestParTask.java
+++ b/test/com/linkedin/parseq/TestParTask.java
@@ -26,17 +26,12 @@ import static org.testng.AssertJUnit.fail;
 public class TestParTask extends BaseEngineTest
 {
   @Test
-  public void testIterableParWithEmptyList()
+  public void testIterableParWithEmptyList() throws InterruptedException
   {
-    try
-    {
-      par(Collections.<Task<?>>emptyList());
-      fail("Should have thrown IllegalArgumentException");
-    }
-    catch (IllegalArgumentException e)
-    {
-      // Expected case
-    }
+    final Task<List<Integer>> par = par(Collections.<Task<Integer>>emptyList());
+    getEngine().run(par);
+    assertTrue(par.await(5, TimeUnit.SECONDS));
+    assertEquals(Collections.<Task<Integer>>emptyList(), par.get());
   }
 
   @Test


### PR DESCRIPTION
This seemed like an easy feature for a first commit, but please let me know if you'd like to see other changes/testing here.
