### PR TITLE
Blocking engine

### DIFF
--- a/contrib/parseq-blocking-engine/pom.xml
+++ b/contrib/parseq-blocking-engine/pom.xml
@@ -12,11 +12,25 @@
 			<artifactId>parseq</artifactId>
 			<version>2.0.6</version>
 		</dependency>
-		<dependency>
-			<groupId>org.reactivestreams</groupId>
-			<artifactId>reactive-streams</artifactId>
-			<version>1.0.0</version>
-		</dependency>
+        <dependency>
+            <groupId>com.linkedin.parseq</groupId>
+            <artifactId>parseq</artifactId>
+            <version>2.0.6</version>
+            <scope>test</scope>
+            <classifier>test</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.9.9</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.6.2</version>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 
     <distributionManagement>

--- a/contrib/parseq-blocking-engine/pom.xml
+++ b/contrib/parseq-blocking-engine/pom.xml
@@ -1,0 +1,107 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.linkedin.parseq</groupId>
+    <artifactId>parseq-blocking-engine</artifactId>
+    <version>2.0.6</version>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.linkedin.parseq</groupId>
+			<artifactId>parseq</artifactId>
+			<version>2.0.6</version>
+		</dependency>
+		<dependency>
+			<groupId>org.reactivestreams</groupId>
+			<artifactId>reactive-streams</artifactId>
+			<version>1.0.0</version>
+		</dependency>
+	</dependencies>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <testSource>1.8</testSource>
+                    <testTarget>1.8</testTarget>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <name>parseq-exec</name>
+    <url>https://github.com/linkedin/parseq</url>
+    <scm>
+    	<url>https://github.com/linkedin/parseq</url>
+    	<connection>scm:git:git://github.com/linkedin/parseq.git</connection>
+    </scm>
+	<description>Provides streaming API for ParSeq Engine.</description>    
+	<licenses>
+		<license>
+			<name>The Apache Software License, Version 2.0</name>
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+	<developers>
+		<developer>
+			<id>jodzga</id>
+			<name>Jaroslaw Odzga</name>
+			<email>jodzga@linkedin.com</email>
+		</developer>
+	</developers>    
+</project>

--- a/contrib/parseq-blocking-engine/src/main/java/com/linkedin/parseq/blocking/BlockingEngine.java
+++ b/contrib/parseq-blocking-engine/src/main/java/com/linkedin/parseq/blocking/BlockingEngine.java
@@ -1,0 +1,141 @@
+package com.linkedin.parseq.blocking;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.linkedin.parseq.Engine;
+import com.linkedin.parseq.Task;
+import com.linkedin.parseq.internal.ArgumentUtil;
+
+
+/**
+ * {@code BlockingEngine} is a wrapper around an {@code Engine} that allows throttling execution of tasks by
+ * blocking a thread that starts a new plan until Engine has a capacity to execute it.
+ * This type of throttling mechanism is useful in situations where synchronous,
+ * single-threaded task producer needs a blocking throttling e.g. in kafka consumer.
+ * If there are multiple single-threaded task producers, e.g. kafka consumers of different topics,
+ * they should all share one instance of {@code BlockingEngine}.
+ * <p>
+ * Example usage in kafka consumer:
+ * <blockquote><pre>
+ * while (_iterator.hasNext()) {
+ *   // get next kafka message
+ *   Record record = _iterator.next();
+ *
+ *   // create task that will process record
+ *   Task{@code <?>} task = processRecord(record);
+ *
+ *   // will block until engine has capacity to process the task
+ *   _blockingEngine.run(task);
+ * }
+ * </pre></blockquote>
+ * {@code BlockingEngine} can be parameterized by specifying how many concurrent plans can be running at any given time.
+ * If tasks are doing only synchronous operations then good value for the max concurrency is number of cores.
+ * If tasks are involved in asynchronous operations such as IO then in order to maximize CPU utilization
+ * max concurrent plans should be higher than number of available cores because it is expected that some of the plans
+ * will be suspended waiting for IO operations to complete.
+ * <p>
+ * {@code BlockingEngine} also provides a FIFO queue in which tasks wait until Engine has capacity to execute them.
+ * <p>
+ * This class is not intended to be used in reactive settings because it is blocking.
+ *
+ * @author Jaroslaw Odzga (jodzga@linkedin.com)
+ */
+public class BlockingEngine {
+
+  public static final int DEFAULT_MAX_CONCURRENCY = 128;
+  public static final int DEFAULT_QUEUE_SIZE = 1024;
+
+  private final Engine _engine;
+  private final Semaphore _demand;
+  private final Queue<Task<?>> _queue = new ConcurrentLinkedQueue<>();
+  private final AtomicInteger _pending = new AtomicInteger(0);
+  private final int _maxConcurrentPlans;
+
+  /**
+   * Creates a wrapper around an Engine that allows throttling execution of tasks by
+   * blocking a thread that starts a new plan until Engine has a capacity to execute it.
+   * <p>
+   * {@code maxConcurrentPlans} specifies how many concurrent plans can be running at any given time.
+   * If task can not be immediately executed because there are {@code maxConcurrentPlans}
+   * plans currently running the task will be added to the waiting FIFO queue.
+   *
+   * @param engine Engine that will be used to execute tasks
+   * @param maxConcurrentPlans maximum number of plans that can be concurrently executed by the Engine
+   * @param queueSize size of the queue for tasks waiting to be executed
+   */
+  public BlockingEngine(Engine engine, int maxConcurrentPlans, int queueSize) {
+    ArgumentUtil.requirePositive(maxConcurrentPlans, "maxConcurrentPlans");
+    ArgumentUtil.requirePositive(queueSize, "queueSize");
+    _maxConcurrentPlans = maxConcurrentPlans;
+    _demand = new Semaphore(maxConcurrentPlans + queueSize);
+    _engine = engine;
+  }
+
+  /**
+   * Runs the given task blocking and waiting until Engine has a capacity to start new plan
+   * or there is a space in the queue to put this task on.
+   * All tasks created and started as a consequence
+   * of this task will belong to that plan and will share a Trace.
+   * @param task
+   * @throws InterruptedException
+   */
+  public void run(final Task<?> task) throws InterruptedException {
+    _demand.acquire();
+    runWithPermit(task);
+  }
+
+  private void runWithPermit(final Task<?> task) {
+
+    task.addListener(p -> {
+      _demand.release();
+      if (_pending.getAndDecrement() > _maxConcurrentPlans) {
+        _engine.run(_queue.poll());
+      }
+    });
+
+    _queue.offer(task);
+    if (_pending.getAndIncrement() < _maxConcurrentPlans) {
+      _engine.run(_queue.poll());
+    }
+  }
+
+  /**
+   * Runs the given task if Engine has a capacity to start new plan or there is a space
+   * in the queue to put this task on.
+   * All tasks created and started as a consequence
+   * of this task will belong to that plan and will share a Trace.
+   * @param task
+   * @return true if Plan was started or placed in the queue
+   */
+  public boolean tryRun(final Task<?> task) {
+    if (_demand.tryAcquire()) {
+      runWithPermit(task);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * Runs the given task blocking and waiting up to specified amount of time until Engine
+   * has a capacity to start new plan or there is a space in the queue to put this task on.
+   * All tasks created and started as a consequence
+   * of this task will belong to that plan and will share a Trace.
+   * @param task
+   * @return true if Plan was started or placed in the queue within the given waiting time and the current thread has not
+   * been {@linkplain Thread#interrupt interrupted}.
+   * @throws InterruptedException
+  */
+  public boolean tryRun(final Task<?> task, final long timeout, final TimeUnit unit) throws InterruptedException {
+    if (_demand.tryAcquire(timeout, unit)) {
+      runWithPermit(task);
+      return true;
+    } else {
+      return false;
+    }
+  }
+}

--- a/contrib/parseq-blocking-engine/src/main/java/com/linkedin/parseq/blocking/BlockingEngine.java
+++ b/contrib/parseq-blocking-engine/src/main/java/com/linkedin/parseq/blocking/BlockingEngine.java
@@ -46,9 +46,6 @@ import com.linkedin.parseq.internal.ArgumentUtil;
  */
 public class BlockingEngine {
 
-  public static final int DEFAULT_MAX_CONCURRENCY = 128;
-  public static final int DEFAULT_QUEUE_SIZE = 1024;
-
   private final Engine _engine;
   private final Semaphore _demand;
   private final Queue<Task<?>> _queue = new ConcurrentLinkedQueue<>();

--- a/contrib/parseq-blocking-engine/src/test/java/com/linkedin/parseq/blocking/TestBlockingEngine.java
+++ b/contrib/parseq-blocking-engine/src/test/java/com/linkedin/parseq/blocking/TestBlockingEngine.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2012 LinkedIn, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.linkedin.parseq.blocking;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.testng.annotations.Test;
+
+import com.linkedin.parseq.BaseEngineTest;
+import com.linkedin.parseq.Task;
+
+/**
+ * @author Jaroslaw Odzga (jodzga@linkedin.com)
+ */
+public class TestBlockingEngine extends BaseEngineTest {
+
+  @Test
+  public void testRunWithinCapacity() throws InterruptedException {
+
+    BlockingEngine blockingEngine = new BlockingEngine(getEngine(), 5, 5);
+    final AtomicInteger counter = new AtomicInteger(0);
+
+    Task<?>[] tasks = new Task<?>[10];
+
+    for (int i = 0; i < 10; i++) {
+      tasks[i] = Task.action(counter::incrementAndGet);
+    }
+
+    for (int i = 0; i < 10; i++) {
+      blockingEngine.run(tasks[i]);
+    }
+
+    assertTrue(tasks[9].await(5, TimeUnit.SECONDS));
+    assertEquals(counter.get(), 10);
+  }
+
+  @Test
+  public void testTryRunWithinCapacity() throws InterruptedException {
+
+    BlockingEngine blockingEngine = new BlockingEngine(getEngine(), 5, 5);
+    final AtomicInteger counter = new AtomicInteger(0);
+
+    Task<?>[] tasks = new Task<?>[10];
+
+    for (int i = 0; i < 10; i++) {
+      tasks[i] = Task.action(counter::incrementAndGet);
+    }
+
+    for (int i = 0; i < 10; i++) {
+      assertTrue(blockingEngine.tryRun(tasks[i]));
+    }
+
+    assertTrue(tasks[9].await(5, TimeUnit.SECONDS));
+    assertEquals(counter.get(), 10);
+  }
+
+  @Test
+  public void testTimeBoundedTryRunWithinCapacity() throws InterruptedException {
+
+    BlockingEngine blockingEngine = new BlockingEngine(getEngine(), 5, 5);
+    final AtomicInteger counter = new AtomicInteger(0);
+
+    Task<?>[] tasks = new Task<?>[10];
+
+    for (int i = 0; i < 10; i++) {
+      tasks[i] = Task.action(counter::incrementAndGet);
+    }
+
+    for (int i = 0; i < 10; i++) {
+      assertTrue(blockingEngine.tryRun(tasks[i], 10, TimeUnit.MILLISECONDS));
+    }
+
+    assertTrue(tasks[9].await(5, TimeUnit.SECONDS));
+    assertEquals(counter.get(), 10);
+  }
+
+  @Test
+  public void testBlocking() throws InterruptedException {
+
+    BlockingEngine blockingEngine = new BlockingEngine(getEngine(), 5, 5);
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    Task<?>[] tasks = new Task<?>[10];
+
+    for (int i = 0; i < 10; i++) {
+      tasks[i] = Task.action(latch::await);
+    }
+
+    //within capacity
+    for (int i = 0; i < 10; i++) {
+      blockingEngine.run(tasks[i]);
+    }
+
+    //blocking one
+    assertFalse(blockingEngine.tryRun(Task.action(() -> {})));
+
+    //release tasks
+    latch.countDown();
+
+    //wait for tasks to finish
+    assertTrue(tasks[9].await(5, TimeUnit.SECONDS));
+
+    //should be unblocked
+    assertTrue(blockingEngine.tryRun(Task.action(() -> {})));
+  }
+
+  @Test
+  public void testTimeBoundedBlocking() throws InterruptedException {
+
+    BlockingEngine blockingEngine = new BlockingEngine(getEngine(), 5, 5);
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    Task<?>[] tasks = new Task<?>[10];
+
+    for (int i = 0; i < 10; i++) {
+      tasks[i] = Task.action(latch::await);
+    }
+
+    //within capacity
+    for (int i = 0; i < 10; i++) {
+      blockingEngine.run(tasks[i]);
+    }
+
+    //time bounded blocking
+    assertFalse(blockingEngine.tryRun(Task.action(() -> {}), 10, TimeUnit.MILLISECONDS));
+
+    //release tasks
+    latch.countDown();
+
+    //wait for tasks to finish
+    assertTrue(tasks[9].await(5, TimeUnit.SECONDS));
+
+    //should be unblocked
+    assertTrue(blockingEngine.tryRun(Task.action(() -> {})));
+  }
+
+
+
+}

--- a/src/com/linkedin/parseq/Engine.java
+++ b/src/com/linkedin/parseq/Engine.java
@@ -114,8 +114,8 @@ public class Engine {
   }
 
   /**
-   * Runs the given task with its own context. Use {@code Tasks.seq} and
-   * {@code Tasks.par} to create and run composite tasks.
+   * Runs the given task. This method starts new Plan. All tasks created and started as a consequence
+   * of this task will belong to that plan and will share a Trace.
    *
    * @param task the task to run
    */
@@ -125,10 +125,11 @@ public class Engine {
   }
 
   /**
-   * Runs the given task with its own context. Use {@code Tasks.seq} and
-   * {@code Tasks.par} to create and run composite tasks.
+   * Runs the given task. This method starts new Plan. All tasks created and started as a consequence
+   * of this task will belong to that plan and will share a Trace.
    *
    * @param task the task to run
+   * @param planClass class of the plan that is used in ParSeq logging
    */
   public void run(final Task<?> task, final String planClass) {
     State currState, newState;


### PR DESCRIPTION
BlockingEngine is a wrapper around an Engine that allows throttling execution of tasks by blocking a thread that starts a new plan until Engine has a capacity to execute it. This type of throttling mechanism is useful in situations where synchronous, single-threaded task producer needs a blocking throttling e.g. in kafka consumer. If there are multiple single-threaded task producers, e.g. kafka consumers of different topics, they should all share one instance of BlockingEngine.

Example usage in kafka consumer:

 while (_iterator.hasNext()) {
   // get next kafka message
   Record record = _iterator.next();

   // create task that will process record
   Task<?> task = processRecord(record);

   // will block until engine has capacity to process the task
   _blockingEngine.run(task);
 }
 
BlockingEngine can be parameterized by specifying how many concurrent plans can be running at any given time. If tasks are doing only synchronous operations then good value for the max concurrency is number of cores. If tasks are involved in asynchronous operations such as IO then in order to maximize CPU utilization max concurrent plans should be higher than number of available cores because it is expected that some of the plans will be suspended waiting for IO operations to complete.
BlockingEngine also provides a FIFO queue in which tasks wait until Engine has capacity to execute them.

BlockingEngine is not intended to be used in reactive settings because it is blocking.