### PR TITLE
Two improvements for parseq-zk-client

### DIFF
--- a/contrib/parseq-zk-client/src/main/java/com/linkedin/parseq/zk/recipes/MultiLocks.java
+++ b/contrib/parseq-zk-client/src/main/java/com/linkedin/parseq/zk/recipes/MultiLocks.java
@@ -5,8 +5,7 @@ import com.linkedin.parseq.zk.client.ZKClient;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
-import static java.util.stream.Collectors.*;
+import java.util.stream.Collectors;
 
 
 /**
@@ -27,7 +26,7 @@ public class MultiLocks implements Synchronizable {
     List<ZKLock> locks = Arrays.stream(lockPaths)
         .sorted()
         .map(lockPath -> new ZKLock(lockPath, zkClient))
-        .collect(toList());
+        .collect(Collectors.toList());
     _locks = Collections.unmodifiableList(locks);
   }
 

--- a/contrib/parseq-zk-client/src/main/java/com/linkedin/parseq/zk/recipes/MultiLocks.java
+++ b/contrib/parseq-zk-client/src/main/java/com/linkedin/parseq/zk/recipes/MultiLocks.java
@@ -1,0 +1,44 @@
+package com.linkedin.parseq.zk.recipes;
+
+import com.linkedin.parseq.Task;
+import com.linkedin.parseq.zk.client.ZKClient;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.stream.Collectors.*;
+
+
+/**
+ * This class represents multiple zookeeper locks that has to be
+ * acquired in an atomic manner. Note that Locks are acquired in
+ * the natural ordering of its lockPath to avoid deadlock.
+ *
+ * @author Ang Xu
+ */
+public class MultiLocks implements Synchronizable {
+
+  /**
+   * an unmodifiable list of {@link ZKLock}s to be acquired in order.
+   */
+  private final List<ZKLock> _locks;
+
+  public MultiLocks(ZKClient zkClient, String... lockPaths)  {
+    List<ZKLock> locks = Arrays.stream(lockPaths)
+        .sorted()
+        .map(lockPath -> new ZKLock(lockPath, zkClient))
+        .collect(toList());
+    _locks = Collections.unmodifiableList(locks);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public <T> Task<T> synchronize(Task<T> task, long deadline) {
+    for (ZKLock lock : _locks) {
+      task = lock.synchronize(task, deadline);
+    }
+    return task;
+  }
+}

--- a/contrib/parseq-zk-client/src/main/java/com/linkedin/parseq/zk/recipes/Synchronizable.java
+++ b/contrib/parseq-zk-client/src/main/java/com/linkedin/parseq/zk/recipes/Synchronizable.java
@@ -1,0 +1,19 @@
+package com.linkedin.parseq.zk.recipes;
+
+import com.linkedin.parseq.Task;
+
+
+/**
+ * @author Ang Xu
+ */
+public interface Synchronizable {
+  /**
+   * Runs the given task while holding this synchronizable.
+   *
+   * @param task task to run
+   * @param deadline the absolute time, in milliseconds, to wait for the synchronizable.
+   *
+   * @return a new task wrapped with {@link ZKLock#synchronize(Task, long)}
+   */
+  <T> Task<T> synchronize(Task<T> task, long deadline);
+}

--- a/contrib/parseq-zk-client/src/main/java/com/linkedin/parseq/zk/recipes/Synchronizable.java
+++ b/contrib/parseq-zk-client/src/main/java/com/linkedin/parseq/zk/recipes/Synchronizable.java
@@ -4,6 +4,9 @@ import com.linkedin.parseq.Task;
 
 
 /**
+ * Synchronizable represents a object upon which {@link Task}s within different plans
+ * can be properly synchronized.
+ *
  * @author Ang Xu
  */
 public interface Synchronizable {

--- a/contrib/parseq-zk-client/src/main/java/com/linkedin/parseq/zk/recipes/ZKLock.java
+++ b/contrib/parseq-zk-client/src/main/java/com/linkedin/parseq/zk/recipes/ZKLock.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Ang Xu
  */
-public class ZKLock {
+public class ZKLock implements Synchronizable {
   private static final Logger LOG = LoggerFactory.getLogger(ZKLock.class);
   private static final String LOCK_INTERNAL_KEY = "lockInternal";
 
@@ -60,13 +60,9 @@ public class ZKLock {
   }
 
   /**
-   * Runs the given task while holding the lock.
-   *
-   * @param task task to run
-   * @param deadline the absolute time, in milliseconds, to wait for the lock
-   *
-   * @return a new task wrapped with {@link ZKLock#synchronize(Task, long)}
+   * {@inheritDoc}
    */
+  @Override
   public <T> Task<T> synchronize(Task<T> task, long deadline) {
     return PlanLocal.get(getPlanLocalKey(), LockInternal.class)
         .flatMap(lockInternal -> {

--- a/contrib/parseq-zk-client/src/test/java/com/linkedin/parseq/zk/client/TestZKClient.java
+++ b/contrib/parseq-zk-client/src/test/java/com/linkedin/parseq/zk/client/TestZKClient.java
@@ -28,9 +28,13 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.Op;
+import org.apache.zookeeper.OpResult;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.Stat;
@@ -264,5 +268,56 @@ public class TestZKClient extends BaseEngineTest {
     Assert.assertNull(waitForDisconnected.get());
   }
 
+  @Test
+  public void testMultiSuccessful() {
+    final String path = "/testMultiSuccessful";
+    final byte[] data1 = "multi1".getBytes();
+    final byte[] data2 = "multi2".getBytes();
+
+    Executor executor = Executors.newFixedThreadPool(2);
+
+    Op[] ops = new Op[] {
+        Op.create(path, data1, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL),
+        Op.setData(path, data2, 0)
+    };
+
+    Task<List<OpResult>> multiOps = _zkClient.multi(Arrays.asList(ops), executor);
+    List<OpResult> result = runAndWait("multiOps", multiOps);
+
+    Assert.assertNotNull(result);
+    Assert.assertEquals(result.size(), 2);
+    Assert.assertEquals(result.get(0).getType(), ZooDefs.OpCode.create);
+    OpResult.CreateResult createResult = (OpResult.CreateResult) result.get(0);
+    Assert.assertEquals(createResult.getPath(), path);
+    Assert.assertEquals(result.get(1).getType(), ZooDefs.OpCode.setData);
+    OpResult.SetDataResult setDataResult = (OpResult.SetDataResult) result.get(1);
+    Assert.assertNotNull(setDataResult.getStat());
+    Assert.assertEquals(setDataResult.getStat().getVersion(), 1);
+  }
+
+  @Test
+  public void testMultiFail()
+      throws InterruptedException {
+    final String path = "/testMultiFail";
+    final String badPath = "/pathDoesntExist";
+    final byte[] data1 = "multi1".getBytes();
+
+    Executor executor = Executors.newFixedThreadPool(2);
+
+    Op[] ops = new Op[] {
+        Op.create(path, data1, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL),
+        Op.delete("/pathDoesntExist", 0)
+    };
+
+    Task<List<OpResult>> multiOps = _zkClient.multi(Arrays.asList(ops), executor);
+    run(multiOps);
+    multiOps.await(10, TimeUnit.SECONDS);
+
+    Assert.assertTrue(multiOps.isFailed());
+    Assert.assertTrue(multiOps.getError() instanceof KeeperException);
+    KeeperException ex = (KeeperException) multiOps.getError();
+    Assert.assertEquals(ex.getPath(), badPath);
+    Assert.assertEquals(ex.code(), KeeperException.Code.NONODE);
+  }
 }
 


### PR DESCRIPTION
This patch contains two improvements for parseq-zk-client.

1. Populate the path information from KeeperException thrown by #multi(Iterable)

2.  Add MultiLocks to zookeeper recipes 