### PR TITLE
Fixing typo in the name of the recovery task

### DIFF
--- a/src/com/linkedin/parseq/Task.java
+++ b/src/com/linkedin/parseq/Task.java
@@ -704,7 +704,7 @@ public interface Task<T> extends Promise<T>, Cancellable {
     final Task<T> that = this;
     return async(desc, context -> {
       final SettablePromise<T> result = Promises.settable();
-      final Task<T> recovery = async("revovery", ctx -> {
+      final Task<T> recovery = async("recovery", ctx -> {
         final SettablePromise<T> recoveryResult = Promises.settable();
         if (that.isFailed()) {
           if (!(Exceptions.isCancellation(that.getError()))) {


### PR DESCRIPTION
Saw revovery task name popping up in the parseq traces. Found that there is a typo in the naming of the task. Hence, fixing the typo in the name of the task.