### PR TITLE
Fixed bug in IndirectRunnable.cancel() method

### DIFF
--- a/src/com/linkedin/parseq/IndirectDelayedExecutor.java
+++ b/src/com/linkedin/parseq/IndirectDelayedExecutor.java
@@ -46,7 +46,7 @@ import com.linkedin.parseq.Cancellable;
 
     public boolean cancel() {
       final Runnable runnable = _commandRef.get();
-      return _commandRef.compareAndSet(runnable, null);
+      return (runnable != null && _commandRef.compareAndSet(runnable, null));
     }
   }
 


### PR DESCRIPTION
Fixed bug in IndirectRunnable.cancel() method which returned true even if Runnable has run or has been cancelled.