### PR TITLE
Changed j.u.Function to c.l.p.f.Function1 that throws an Exception.

### DIFF
--- a/contrib/parseq-retry/src/main/java/com/linkedin/parseq/retry/RetriableTask.java
+++ b/contrib/parseq-retry/src/main/java/com/linkedin/parseq/retry/RetriableTask.java
@@ -1,18 +1,19 @@
 package com.linkedin.parseq.retry;
 
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.linkedin.parseq.Context;
 import com.linkedin.parseq.Priority;
 import com.linkedin.parseq.Task;
+import com.linkedin.parseq.function.Function1;
 import com.linkedin.parseq.internal.ArgumentUtil;
 import com.linkedin.parseq.promise.Promise;
 import com.linkedin.parseq.promise.Promises;
 import com.linkedin.parseq.promise.SettablePromise;
-
-import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -28,7 +29,7 @@ public final class RetriableTask<T> {
   private final String _name;
 
   /** A task generator function. It will receive a zero-based attempt number as a parameter. */
-  private final Function<Integer, Task<T>> _taskFunction;
+  private final Function1<Integer, Task<T>> _taskFunction;
 
   /** Retry policy which will control this task's behavior. */
   private final RetryPolicy _policy;
@@ -43,7 +44,7 @@ public final class RetriableTask<T> {
    * @param policy Retry policy that will control this task's behavior.
    * @param taskFunction A task generator function. It will receive a zero-based attempt number as a parameter.
    */
-  private RetriableTask(String name, RetryPolicy policy, Function<Integer, Task<T>> taskFunction)
+  private RetriableTask(String name, RetryPolicy policy, Function1<Integer, Task<T>> taskFunction)
   {
     ArgumentUtil.requireNotNull(name, "name");
     ArgumentUtil.requireNotNull(policy, "policy");
@@ -61,8 +62,8 @@ public final class RetriableTask<T> {
    * @param taskSupplier A task generator function.
    * @param <U> Type of a task result.
    */
-  public static <U> Task<U> withRetryPolicy(RetryPolicy policy, Supplier<Task<U>> taskSupplier) {
-    return withRetryPolicy("operation", policy, attempt -> taskSupplier.get());
+  public static <U> Task<U> withRetryPolicy(RetryPolicy policy, Callable<Task<U>> taskSupplier) {
+    return withRetryPolicy("operation", policy, attempt -> taskSupplier.call());
   }
 
   /**
@@ -72,7 +73,7 @@ public final class RetriableTask<T> {
    * @param taskFunction A task generator function. It will receive a zero-based attempt number as a parameter.
    * @param <U> Type of a task result.
    */
-  public static <U> Task<U> withRetryPolicy(RetryPolicy policy, Function<Integer, Task<U>> taskFunction) {
+  public static <U> Task<U> withRetryPolicy(RetryPolicy policy, Function1<Integer, Task<U>> taskFunction) {
     return withRetryPolicy("operation", policy, taskFunction);
   }
 
@@ -84,8 +85,8 @@ public final class RetriableTask<T> {
    * @param taskSupplier A task generator function.
    * @param <U> Type of a task result.
    */
-  public static <U> Task<U> withRetryPolicy(String name, RetryPolicy policy, Supplier<Task<U>> taskSupplier) {
-    return withRetryPolicy(name, policy, attempt -> taskSupplier.get());
+  public static <U> Task<U> withRetryPolicy(String name, RetryPolicy policy, Callable<Task<U>> taskSupplier) {
+    return withRetryPolicy(name, policy, attempt -> taskSupplier.call());
   }
 
   /**
@@ -96,17 +97,17 @@ public final class RetriableTask<T> {
    * @param taskFunction A task generator function. It will receive a zero-based attempt number as a parameter.
    * @param <U> Type of a task result.
    */
-  public static <U> Task<U> withRetryPolicy(String name, RetryPolicy policy, Function<Integer, Task<U>> taskFunction) {
+  public static <U> Task<U> withRetryPolicy(String name, RetryPolicy policy, Function1<Integer, Task<U>> taskFunction) {
     RetriableTask<U> retriableTask = new RetriableTask<>(name, policy, taskFunction);
     return Task.async(name + " retriableTask", retriableTask::run);
   }
 
   /** Create a wrapped task with associated recovery task that will retry if necessary. */
   private Task<T> wrap(int attempt) {
-    Task<T> task = _taskFunction.apply(attempt);
-
     return Task.async(_policy.getName() + ", attempt " + attempt, context -> {
       final SettablePromise<T> result = Promises.settable();
+
+      Task<T> task = _taskFunction.apply(attempt);
 
       final Task<T> recovery = Task.async(_name + " recovery", recoveryContext -> {
         final SettablePromise<T> recoveryResult = Promises.settable();

--- a/contrib/parseq-retry/src/test/java/com/linkedin/parseq/retry/TestRetriableTask.java
+++ b/contrib/parseq-retry/src/test/java/com/linkedin/parseq/retry/TestRetriableTask.java
@@ -1,0 +1,69 @@
+package com.linkedin.parseq.retry;
+
+import static com.linkedin.parseq.retry.RetriableTask.withRetryPolicy;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+import org.testng.annotations.Test;
+
+import com.linkedin.parseq.BaseEngineTest;
+import com.linkedin.parseq.Task;
+import com.linkedin.parseq.retry.termination.TerminationPolicy;
+
+
+public class TestRetriableTask extends BaseEngineTest {
+  @Test
+  public void testSuccessfulTask()
+  {
+    Task<String> task = withRetryPolicy(RetryPolicy.attempts(3, 0), attempt -> Task.value("successful attempt " + attempt));
+    runAndWait(task);
+    assertTrue(task.isDone());
+    assertEquals(task.get(), "successful attempt 0");
+  }
+
+  @Test
+  public void testSimpleRetryPolicy()
+  {
+    Task<Void> task = withRetryPolicy("testSimpleRetryPolicy", RetryPolicy.attempts(3, 0),
+        attempt -> Task.failure(new RuntimeException("current attempt: " + attempt)));
+    runAndWaitException(task, RuntimeException.class);
+    assertTrue(task.isDone());
+    assertEquals(task.getError().getMessage(), "current attempt: 2");
+  }
+
+  @Test
+  public void testErrorClassification()
+  {
+    Function<Throwable, ErrorClassification> errorClassifier = error -> error instanceof TimeoutException ? ErrorClassification.RECOVERABLE : ErrorClassification.UNRECOVERABLE;
+
+    RetryPolicy retryPolicy = new RetryPolicyBuilder().
+        setTerminationPolicy(TerminationPolicy.limitAttempts(3)).
+        setErrorClassifier(errorClassifier).
+        build();
+    assertEquals(retryPolicy.getName(), "RetryPolicy.LimitAttempts");
+
+    Task<Void> task1 = withRetryPolicy("testErrorClassification", retryPolicy, attempt -> Task.failure(new TimeoutException("current attempt: " + attempt)));
+    runAndWaitException(task1, TimeoutException.class);
+    assertTrue(task1.isDone());
+    assertEquals(task1.getError().getMessage(), "current attempt: 2");
+
+    Task<Void> task2 = withRetryPolicy("testErrorClassification", retryPolicy, attempt -> Task.failure(new IllegalArgumentException("current attempt: " + attempt)));
+    runAndWaitException(task2, IllegalArgumentException.class);
+    assertTrue(task2.isDone());
+    assertEquals(task2.getError().getMessage(), "current attempt: 0");
+  }
+
+  @Test
+  public void testFailingTaskSupplier()
+  {
+    Task<Void> task = withRetryPolicy("testFailingTaskSupplier", RetryPolicy.attempts(3, 0),
+        attempt -> { throw new IOException("ups"); });
+    runAndWaitException(task, IOException.class);
+    assertTrue(task.isDone());
+  }
+
+}


### PR DESCRIPTION
This is for developers' convenience - they don't have to take care of checked exceptions and leave error handling to ParSeq.
Unit test shows how function can throw a checked exception.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/linkedin/parseq/93)
<!-- Reviewable:end -->
