### PR TITLE
Allow user to wire custom TaskQueue implementation into SerialExecutor

### DIFF
--- a/src/com/linkedin/parseq/EngineBuilder.java
+++ b/src/com/linkedin/parseq/EngineBuilder.java
@@ -16,7 +16,6 @@
 
 package com.linkedin.parseq;
 
-import com.linkedin.parseq.internal.PlanCompletionListener;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executor;
@@ -27,6 +26,8 @@ import org.slf4j.LoggerFactory;
 
 import com.linkedin.parseq.internal.ArgumentUtil;
 import com.linkedin.parseq.internal.CachedLoggerFactory;
+import com.linkedin.parseq.internal.FIFOPriorityQueue;
+import com.linkedin.parseq.internal.PlanCompletionListener;
 import com.linkedin.parseq.internal.PlanDeactivationListener;
 
 /**
@@ -47,6 +48,7 @@ public class EngineBuilder {
   private ILoggerFactory _loggerFactory;
   private PlanDeactivationListener _planDeactivationListener;
   private PlanCompletionListener _planCompletionListener;
+  private TaskQueueFactory _taskQueueFactory;
 
   private Map<String, Object> _properties = new HashMap<String, Object>();
 
@@ -73,6 +75,12 @@ public class EngineBuilder {
   public EngineBuilder setPlanCompletionListener(PlanCompletionListener planCompletionListener) {
     ArgumentUtil.requireNotNull(planCompletionListener, "planCompletionListener");
     _planCompletionListener = planCompletionListener;
+    return this;
+  }
+
+  public EngineBuilder setTaskQueueFactory(TaskQueueFactory taskQueueFactory) {
+    ArgumentUtil.requireNotNull(taskQueueFactory, "taskQueueFactory");
+    _taskQueueFactory = taskQueueFactory;
     return this;
   }
 
@@ -161,7 +169,8 @@ public class EngineBuilder {
     return new Engine(_taskExecutor, new IndirectDelayedExecutor(_timerScheduler),
         _loggerFactory != null ? _loggerFactory : new CachedLoggerFactory(LoggerFactory.getILoggerFactory()),
         _properties, _planDeactivationListener != null ? _planDeactivationListener : planContext -> {},
-        _planCompletionListener != null ? _planCompletionListener : planContext -> {});
+        _planCompletionListener != null ? _planCompletionListener : planContext -> {},
+        _taskQueueFactory != null ? _taskQueueFactory : FIFOPriorityQueue::new);
   }
 
   /**

--- a/src/com/linkedin/parseq/Task.java
+++ b/src/com/linkedin/parseq/Task.java
@@ -16,6 +16,7 @@
 
 package com.linkedin.parseq;
 
+import com.linkedin.parseq.internal.Prioritizable;
 import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;

--- a/src/com/linkedin/parseq/TaskQueueFactory.java
+++ b/src/com/linkedin/parseq/TaskQueueFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 LinkedIn, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.linkedin.parseq;
+
+import com.linkedin.parseq.internal.PrioritizableRunnable;
+import com.linkedin.parseq.internal.SerialExecutor;
+
+
+/**
+ * A factory to create {@link com.linkedin.parseq.internal.SerialExecutor.TaskQueue}s.
+ *
+ * @author Ang Xu
+ */
+public interface TaskQueueFactory {
+  SerialExecutor.TaskQueue<PrioritizableRunnable> newTaskQueue();
+}

--- a/src/com/linkedin/parseq/internal/FIFOPriorityQueue.java
+++ b/src/com/linkedin/parseq/internal/FIFOPriorityQueue.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * @author Chris Pettitt (cpettitt@linkedin.com)
  */
 public class FIFOPriorityQueue<T extends Prioritizable> implements SerialExecutor.TaskQueue<T> {
-  private final BlockingQueue<Entry> _queue = new PriorityBlockingQueue<>();
+  private final BlockingQueue<Entry<T>> _queue = new PriorityBlockingQueue<>();
   private final AtomicLong _sequenceNumber = new AtomicLong();
 
   public FIFOPriorityQueue() {}
@@ -49,7 +49,7 @@ public class FIFOPriorityQueue<T extends Prioritizable> implements SerialExecuto
     }
 
     @Override
-    public int compareTo(final Entry o) {
+    public int compareTo(final Entry<T> o) {
       final int comp = compare(o._value.getPriority(), _value.getPriority());
       return comp == 0 ? compare(_sequenceNumber, o._sequenceNumber) : comp;
     }

--- a/src/com/linkedin/parseq/internal/PlanContext.java
+++ b/src/com/linkedin/parseq/internal/PlanContext.java
@@ -55,7 +55,7 @@ public class PlanContext {
   public PlanContext(final Engine engine, final Executor taskExecutor, final DelayedExecutor timerExecutor,
       final ILoggerFactory loggerFactory, final Logger allLogger, final Logger rootLogger, final String planClass,
       Task<?> root, final int maxRelationshipsPerTrace, final PlanDeactivationListener planDeactivationListener,
-      PlanCompletionListener planCompletionListener) {
+      PlanCompletionListener planCompletionListener, final SerialExecutor.TaskQueue<PrioritizableRunnable> taskQueue) {
     _id = IdGenerator.getNextId();
     _root = root;
     _relationshipsBuilder = new TraceBuilder(maxRelationshipsPerTrace, planClass, _id);
@@ -66,7 +66,7 @@ public class PlanContext {
       } catch (Throwable t) {
         LOG.error("Failed to notify deactivation listener " + planDeactivationListener, t);
       }
-    });
+    }, taskQueue);
     _timerScheduler = timerExecutor;
     final Logger planLogger = loggerFactory.getLogger(Engine.LOGGER_BASE + ":planClass=" + planClass);
     _taskLogger = new TaskLogger(_id, root.getId(), allLogger, rootLogger, planLogger);

--- a/src/com/linkedin/parseq/internal/PlanContext.java
+++ b/src/com/linkedin/parseq/internal/PlanContext.java
@@ -102,7 +102,7 @@ public class PlanContext {
     return _id;
   }
 
-  public void execute(Runnable runnable) {
+  public void execute(PrioritizableRunnable runnable) {
     _taskExecutor.execute(runnable);
   }
 

--- a/src/com/linkedin/parseq/internal/PrioritizableRunnable.java
+++ b/src/com/linkedin/parseq/internal/PrioritizableRunnable.java
@@ -16,8 +16,17 @@
 
 package com.linkedin.parseq.internal;
 
+import com.linkedin.parseq.Priority;
+
+
 /**
  * @author Chris Pettitt (cpettitt@linkedin.com)
  */
 public interface PrioritizableRunnable extends Runnable, Prioritizable {
+
+  @Override
+  default int getPriority() {
+    return Priority.DEFAULT_PRIORITY;
+  }
+
 }

--- a/src/com/linkedin/parseq/internal/SerialExecutor.java
+++ b/src/com/linkedin/parseq/internal/SerialExecutor.java
@@ -16,7 +16,6 @@
 
 package com.linkedin.parseq.internal;
 
-import com.linkedin.parseq.Priority;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -40,7 +39,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @author Chris Pettitt (cpettitt@linkedin.com)
  * @author Jaroslaw Odzga (jodzga@linkedin.com)
  */
-public class SerialExecutor implements Executor {
+public class SerialExecutor {
 
   /*
    * Below is a proof and description of a mechanism that ensures that
@@ -88,22 +87,8 @@ public class SerialExecutor implements Executor {
     _deactivationListener = deactivationListener;
   }
 
-  public void execute(final Runnable runnable) {
-    if (runnable instanceof Prioritizable) {
-      _queue.add((PrioritizableRunnable)runnable);
-    } else {
-      _queue.add(new PrioritizableRunnable() {
-        @Override
-        public int getPriority() {
-          return Priority.DEFAULT_PRIORITY;
-        }
-
-        @Override
-        public void run() {
-          runnable.run();
-        }
-      });
-    }
+  public void execute(final PrioritizableRunnable runnable) {
+    _queue.add(runnable);
     // Guarantees that execution loop is scheduled only once to the underlying executor.
     // Also makes sure that all memory effects of last Runnable are visible to the next Runnable
     // in case value returned by decrementAndGet == 0.

--- a/test/com/linkedin/parseq/internal/TestFIFOPriorityQueue.java
+++ b/test/com/linkedin/parseq/internal/TestFIFOPriorityQueue.java
@@ -16,6 +16,7 @@
 
 package com.linkedin.parseq.internal;
 
+import com.linkedin.parseq.Priority;
 import org.testng.annotations.Test;
 
 import static org.testng.AssertJUnit.assertEquals;
@@ -28,26 +29,26 @@ import static org.testng.AssertJUnit.assertNull;
 public class TestFIFOPriorityQueue {
   @Test
   public void testPollOnEmpty() {
-    final FIFOPriorityQueue<Object> queue = new FIFOPriorityQueue<Object>();
+    final FIFOPriorityQueue<?> queue = new FIFOPriorityQueue<>();
     assertNull(queue.poll());
   }
 
   @Test
   public void testPollOnUnprioritizedSequence() {
-    final FIFOPriorityQueue<Integer> queue = new FIFOPriorityQueue<Integer>();
-    queue.add(1);
-    queue.add(2);
-    queue.add(3);
+    final FIFOPriorityQueue<PrioritizableInt> queue = new FIFOPriorityQueue<>();
+    queue.add(new PrioritizableInt(1));
+    queue.add(new PrioritizableInt(2));
+    queue.add(new PrioritizableInt(3));
 
-    assertEquals((Integer) 1, queue.poll());
-    assertEquals((Integer) 2, queue.poll());
-    assertEquals((Integer) 3, queue.poll());
+    assertEquals(1, queue.poll().getValue());
+    assertEquals(2, queue.poll().getValue());
+    assertEquals(3, queue.poll().getValue());
     assertNull(queue.poll());
   }
 
   @Test
   public void testPollWithPriority() {
-    final FIFOPriorityQueue<Int> queue = new FIFOPriorityQueue<Int>();
+    final FIFOPriorityQueue<PrioritizableInt> queue = new FIFOPriorityQueue<>();
     queue.add(new PrioritizableInt(-5, 1));
     queue.add(new PrioritizableInt(10, 2));
     queue.add(new PrioritizableInt(0, 3));
@@ -59,7 +60,7 @@ public class TestFIFOPriorityQueue {
 
   @Test
   public void testPollWithOverlappingPriorities() {
-    final FIFOPriorityQueue<Int> queue = new FIFOPriorityQueue<Int>();
+    final FIFOPriorityQueue<PrioritizableInt> queue = new FIFOPriorityQueue<>();
     queue.add(new PrioritizableInt(-5, 1));
     queue.add(new PrioritizableInt(10, 2));
     queue.add(new PrioritizableInt(0, 3));
@@ -77,10 +78,10 @@ public class TestFIFOPriorityQueue {
 
   @Test
   public void testPollWithDefaultPriority() {
-    final FIFOPriorityQueue<Int> queue = new FIFOPriorityQueue<Int>();
+    final FIFOPriorityQueue<PrioritizableInt> queue = new FIFOPriorityQueue<>();
     queue.add(new PrioritizableInt(-5, 1));
     queue.add(new PrioritizableInt(10, 2));
-    queue.add(new Int(3));
+    queue.add(new PrioritizableInt(3));
 
     assertEquals(2, queue.poll().getValue());
     assertEquals(3, queue.poll().getValue());
@@ -101,6 +102,10 @@ public class TestFIFOPriorityQueue {
 
   private static class PrioritizableInt extends Int implements Prioritizable {
     private final int _priority;
+
+    private PrioritizableInt(final int value) {
+      this(Priority.DEFAULT_PRIORITY, value);
+    }
 
     private PrioritizableInt(final int priority, final int value) {
       super(value);

--- a/test/com/linkedin/parseq/internal/TestSerialExecutor.java
+++ b/test/com/linkedin/parseq/internal/TestSerialExecutor.java
@@ -27,11 +27,12 @@ public class TestSerialExecutor {
 
   @BeforeMethod
   public void setUp() {
-    _executorService = new ThreadPoolExecutor(1, 1, 0, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(1),
+    _executorService = new ThreadPoolExecutor(1, 1, 0, TimeUnit.SECONDS, new ArrayBlockingQueue<>(1),
         new ThreadPoolExecutor.AbortPolicy());
     _rejectionHandler = new CapturingRejectionHandler();
     _capturingDeactivationListener = new CapturingActivityListener();
-    _serialExecutor = new SerialExecutor(_executorService, _rejectionHandler, _capturingDeactivationListener);
+    _serialExecutor = new SerialExecutor(_executorService, _rejectionHandler, _capturingDeactivationListener,
+        new FIFOPriorityQueue<>());
   }
 
   @AfterMethod

--- a/test/com/linkedin/parseq/internal/TestSerialExecutor.java
+++ b/test/com/linkedin/parseq/internal/TestSerialExecutor.java
@@ -129,7 +129,7 @@ public class TestSerialExecutor {
         _rejectionHandler.getLastError() instanceof RejectedExecutionException);
   }
 
-  private static class NeverEndingRunnable implements Runnable {
+  private static class NeverEndingRunnable implements PrioritizableRunnable {
     @Override
     public void run() {
       try {
@@ -183,7 +183,7 @@ public class TestSerialExecutor {
     }
   }
 
-  private static class LatchedRunnable implements Runnable {
+  private static class LatchedRunnable implements PrioritizableRunnable {
     private final CountDownLatch _latch = new CountDownLatch(1);
 
     @Override


### PR DESCRIPTION
This patch should give us the ability to override the default FIFOPriorityQueue implementation in SerialExecutor.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/linkedin/parseq/95)

<!-- Reviewable:end -->
