### PR TITLE
Unit test showing bug in batching shareable tasks.

### DIFF
--- a/contrib/parseq-batching/src/test/java/com/linkedin/parseq/batching/TestSimpleBatchingStrategy.java
+++ b/contrib/parseq-batching/src/test/java/com/linkedin/parseq/batching/TestSimpleBatchingStrategy.java
@@ -59,4 +59,15 @@ public class TestSimpleBatchingStrategy extends BaseEngineTest {
     assertEquals(result, "01");
   }
 
+  @Test
+  public void testShareable() {
+
+    Task<String> task = Task.par(_strategy.batchable(0).shareable(), _strategy.batchable(1).shareable())
+        .map("concat", (s0, s1) -> s0 + s1);
+
+    String result = runAndWait("TestSimpleBatchingStrategy.testShareable", task);
+
+    assertEquals(result, "01");
+  }
+
 }


### PR DESCRIPTION
Unit test showing bug caused by interaction of forking plans for side effects and batching.

The problem is that batching uses plan id as a key for aggregation but side effects fork plans what creates new plan ids and as a consequence batchable tasks never get executed.
This bug affects side effects in general and shareable() method because it uses runSideEffect()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/linkedin/parseq/98)
<!-- Reviewable:end -->
