### PR TITLE
Added RequestContext provider to ParSeqRestClient.

### DIFF
--- a/contrib/parseq-restli-client/src/main/java/com/linkedin/restli/client/ParSeqRestliClientBuilder.java
+++ b/contrib/parseq-restli-client/src/main/java/com/linkedin/restli/client/ParSeqRestliClientBuilder.java
@@ -54,7 +54,7 @@ public class ParSeqRestliClientBuilder {
 
     RequestConfigProvider configProvider = new MultipleRequestConfigProvider(_configs, _configChooser, inboundRequestContextFinder);
     Function<Request<?>, RequestContext> requestContextProvider = (_requestContextProvider == null) ?
-        requet -> new RequestContext() :
+        request -> new RequestContext() :
         _requestContextProvider;
 
     ParSeqRestClient parseqClient = new ParSeqRestClient(_restClient, configProvider, requestContextProvider);

--- a/contrib/parseq-restli-client/src/main/java/com/linkedin/restli/client/ParSeqRestliClientBuilder.java
+++ b/contrib/parseq-restli-client/src/main/java/com/linkedin/restli/client/ParSeqRestliClientBuilder.java
@@ -3,12 +3,14 @@ package com.linkedin.restli.client;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linkedin.parseq.batching.BatchingSupport;
 import com.linkedin.parseq.internal.ArgumentUtil;
+import com.linkedin.r2.message.RequestContext;
 import com.linkedin.restli.client.config.RequestConfigProvider;
 
 public class ParSeqRestliClientBuilder {
@@ -24,6 +26,7 @@ public class ParSeqRestliClientBuilder {
 
   private BatchingSupport _batchingSupport;
   private InboundRequestContextFinder _inboundRequestContextFinder;
+  private Function<Request<?>, RequestContext> _requestContextProvider;
 
   /**
    * This method may throw RuntimeException e.g. when there is a problem with configuration.
@@ -50,8 +53,11 @@ public class ParSeqRestliClientBuilder {
     }
 
     RequestConfigProvider configProvider = new MultipleRequestConfigProvider(_configs, _configChooser, inboundRequestContextFinder);
+    Function<Request<?>, RequestContext> requestContextProvider = (_requestContextProvider == null) ?
+        requet -> new RequestContext() :
+        _requestContextProvider;
 
-    ParSeqRestClient parseqClient = new ParSeqRestClient(_restClient, configProvider);
+    ParSeqRestClient parseqClient = new ParSeqRestClient(_restClient, configProvider, requestContextProvider);
     if (_batchingSupport != null) {
       LOGGER.debug("Found batching support");
       _batchingSupport.registerStrategy(parseqClient);
@@ -73,6 +79,12 @@ public class ParSeqRestliClientBuilder {
   public ParSeqRestliClientBuilder setRestClient(RestClient restClient) {
     ArgumentUtil.requireNotNull(restClient, "restClient");
     _restClient = restClient;
+    return this;
+  }
+
+  public ParSeqRestliClientBuilder setRequestContextProvider(Function<Request<?>, RequestContext> requestContextProvider) {
+    ArgumentUtil.requireNotNull(requestContextProvider, "requestContextProvider");
+    _requestContextProvider = requestContextProvider;
     return this;
   }
 

--- a/contrib/parseq-restli-client/src/main/java/com/linkedin/restli/client/RequestGroup.java
+++ b/contrib/parseq-restli-client/src/main/java/com/linkedin/restli/client/RequestGroup.java
@@ -16,8 +16,11 @@
 
 package com.linkedin.restli.client;
 
+import java.util.function.Function;
+
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.parseq.batching.Batch;
+import com.linkedin.r2.message.RequestContext;
 import com.linkedin.restli.client.config.RequestConfig;
 import com.linkedin.restli.common.ResourceMethod;
 
@@ -41,7 +44,7 @@ interface RequestGroup {
   }
 
   <RT extends RecordTemplate> void executeBatch(RestClient restClient,
-      Batch<RestRequestBatchKey, Response<Object>> batch);
+      Batch<RestRequestBatchKey, Response<Object>> batch, Function<Request<?>, RequestContext> requestContextProvider);
 
   <K, V> String getBatchName(Batch<K, V> batch);
 

--- a/contrib/parseq-restli-client/src/test/java/com/linkedin/restli/client/CapturingRestClient.java
+++ b/contrib/parseq-restli-client/src/test/java/com/linkedin/restli/client/CapturingRestClient.java
@@ -1,0 +1,119 @@
+package com.linkedin.restli.client;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.linkedin.common.callback.Callback;
+import com.linkedin.common.util.None;
+import com.linkedin.r2.message.RequestContext;
+import com.linkedin.r2.message.rest.RestResponse;
+import com.linkedin.r2.transport.common.Client;
+import com.linkedin.restli.client.multiplexer.MultiplexedRequest;
+import com.linkedin.restli.client.multiplexer.MultiplexedResponse;
+
+class CapturingRestClient extends RestClient {
+
+  private final Map<Request<?>, RequestContext> _capturedRequestContexts = new ConcurrentHashMap<>();
+
+  public Map<Request<?>, RequestContext> getCapturedRequestContexts() {
+    return _capturedRequestContexts;
+  }
+
+  public void clearCapturedRequestContexts() {
+    _capturedRequestContexts.clear();
+  }
+
+  private final RestClient _delegate;
+
+  public int hashCode() {
+    return _delegate.hashCode();
+  }
+
+  public boolean equals(Object obj) {
+    return _delegate.equals(obj);
+  }
+
+  public void shutdown(Callback<None> callback) {
+    _delegate.shutdown(callback);
+  }
+
+  public <T> ResponseFuture<T> sendRequest(Request<T> request, RequestContext requestContext) {
+    _capturedRequestContexts.put(request, requestContext);
+    return _delegate.sendRequest(request, requestContext);
+  }
+
+  public <T> ResponseFuture<T> sendRequest(Request<T> request, RequestContext requestContext,
+      ErrorHandlingBehavior errorHandlingBehavior) {
+    _capturedRequestContexts.put(request, requestContext);
+    return _delegate.sendRequest(request, requestContext, errorHandlingBehavior);
+  }
+
+  public <T> ResponseFuture<T> sendRequest(RequestBuilder<? extends Request<T>> requestBuilder,
+      RequestContext requestContext) {
+    return _delegate.sendRequest(requestBuilder, requestContext);
+  }
+
+  public <T> ResponseFuture<T> sendRequest(RequestBuilder<? extends Request<T>> requestBuilder,
+      RequestContext requestContext, ErrorHandlingBehavior errorHandlingBehavior) {
+    return _delegate.sendRequest(requestBuilder, requestContext, errorHandlingBehavior);
+  }
+
+  public String toString() {
+    return _delegate.toString();
+  }
+
+  public <T> void sendRequest(Request<T> request, RequestContext requestContext, Callback<Response<T>> callback) {
+    _capturedRequestContexts.put(request, requestContext);
+    _delegate.sendRequest(request, requestContext, callback);
+  }
+
+  public <T> void sendRestRequest(Request<T> request, RequestContext requestContext,
+      Callback<RestResponse> callback) {
+    _capturedRequestContexts.put(request, requestContext);
+    _delegate.sendRestRequest(request, requestContext, callback);
+  }
+
+  public <T> void sendRequest(RequestBuilder<? extends Request<T>> requestBuilder, RequestContext requestContext,
+      Callback<Response<T>> callback) {
+    _delegate.sendRequest(requestBuilder, requestContext, callback);
+  }
+
+  public <T> ResponseFuture<T> sendRequest(Request<T> request) {
+    return _delegate.sendRequest(request);
+  }
+
+  public <T> ResponseFuture<T> sendRequest(Request<T> request, ErrorHandlingBehavior errorHandlingBehavior) {
+    return _delegate.sendRequest(request, errorHandlingBehavior);
+  }
+
+  public <T> ResponseFuture<T> sendRequest(RequestBuilder<? extends Request<T>> requestBuilder) {
+    return _delegate.sendRequest(requestBuilder);
+  }
+
+  public <T> ResponseFuture<T> sendRequest(RequestBuilder<? extends Request<T>> requestBuilder,
+      ErrorHandlingBehavior errorHandlingBehavior) {
+    return _delegate.sendRequest(requestBuilder, errorHandlingBehavior);
+  }
+
+  public <T> void sendRequest(Request<T> request, Callback<Response<T>> callback) {
+    _delegate.sendRequest(request, callback);
+  }
+
+  public <T> void sendRequest(RequestBuilder<? extends Request<T>> requestBuilder, Callback<Response<T>> callback) {
+    _delegate.sendRequest(requestBuilder, callback);
+  }
+
+  public void sendRequest(MultiplexedRequest multiplexedRequest) {
+    _delegate.sendRequest(multiplexedRequest);
+  }
+
+  public void sendRequest(MultiplexedRequest multiplexedRequest, Callback<MultiplexedResponse> callback) {
+    _delegate.sendRequest(multiplexedRequest, callback);
+  }
+
+  public CapturingRestClient(Client client, String uriPrefix, RestClient delegate) {
+    super(client, uriPrefix);
+    _delegate = delegate;
+  }
+
+}

--- a/contrib/parseq-restli-client/src/test/java/com/linkedin/restli/client/ParSeqRestClientIntegrationTest.java
+++ b/contrib/parseq-restli-client/src/test/java/com/linkedin/restli/client/ParSeqRestClientIntegrationTest.java
@@ -92,8 +92,12 @@ public abstract class ParSeqRestClientIntegrationTest extends BaseEngineTest {
     _server.start();
     _clientFactory = new HttpClientFactory();
     _transportClients = new ArrayList<Client>();
+    _restClient = createRestClient();
+  }
+
+  protected RestClient createRestClient() {
     Client client = newTransportClient(Collections.<String, String> emptyMap());
-    _restClient = new RestClient(client, URI_PREFIX);
+    return new RestClient(client, URI_PREFIX);
   }
 
   @AfterClass
@@ -125,17 +129,22 @@ public abstract class ParSeqRestClientIntegrationTest extends BaseEngineTest {
     return client;
   }
 
+  protected void customizeParSeqRestliClient(ParSeqRestliClientBuilder parSeqRestliClientBuilder) {
+  }
+
   @Override
   protected void customizeEngine(EngineBuilder engineBuilder) {
     engineBuilder.setPlanDeactivationListener(_batchingSupport);
 
-
-    _parseqClient = new ParSeqRestliClientBuilder()
+    ParSeqRestliClientBuilder parSeqRestliClientBuilder = new ParSeqRestliClientBuilder()
         .setRestClient(_restClient)
         .setBatchingSupport(_batchingSupport)
         .setConfig(getParSeqRestClientConfig())
-        .setInboundRequestContextFinder(() -> Optional.ofNullable(_inboundRequestContext.get()))
-        .build();
+        .setInboundRequestContextFinder(() -> Optional.ofNullable(_inboundRequestContext.get()));
+
+    customizeParSeqRestliClient(parSeqRestliClientBuilder);
+
+    _parseqClient = parSeqRestliClientBuilder.build();
   }
 
   protected Task<String> toMessage(Task<Response<Greeting>> greeting) {

--- a/contrib/parseq-restli-client/src/test/java/com/linkedin/restli/client/TestRequestContextProvider.java
+++ b/contrib/parseq-restli-client/src/test/java/com/linkedin/restli/client/TestRequestContextProvider.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2016 LinkedIn, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.linkedin.restli.client;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Collection;
+
+import org.testng.annotations.Test;
+
+import com.linkedin.parseq.Task;
+import com.linkedin.r2.message.RequestContext;
+import com.linkedin.restli.client.config.RequestConfigOverridesBuilder;
+import com.linkedin.restli.common.ResourceMethod;
+import com.linkedin.restli.examples.greetings.api.Greeting;
+import com.linkedin.restli.examples.greetings.client.GreetingsBuilders;
+
+public class TestRequestContextProvider extends ParSeqRestClientIntegrationTest {
+
+  private CapturingRestClient _capturingRestClient;
+
+  @Override
+  public ParSeqRestliClientConfig getParSeqRestClientConfig() {
+    return new ParSeqRestliClientConfigBuilder()
+        .addTimeoutMs("*.*/greetings.GET", 9999L)
+        .addTimeoutMs("*.*/greetings.*", 10001L)
+        .addTimeoutMs("*.*/*.GET", 10002L)
+        .addTimeoutMs("foo.*/greetings.GET", 10003L)
+        .addTimeoutMs("foo.GET/greetings.GET", 10004L)
+        .addTimeoutMs("foo.ACTION-*/greetings.GET", 10005L)
+        .addTimeoutMs("foo.ACTION-bar/greetings.GET", 10006L)
+        .addBatchingEnabled("withBatching.*/*.*", true)
+        .addMaxBatchSize("withBatching.*/*.*", 3)
+        .build();
+  }
+
+  @Override
+  protected RestClient createRestClient() {
+    _capturingRestClient = new CapturingRestClient(null,  null, super.createRestClient());
+    return _capturingRestClient;
+  }
+
+  private <T> RequestContext createRequestContext(Request<T> request) {
+    RequestContext requestContext = new RequestContext();
+    requestContext.putLocalAttr("method", request.getMethod());
+    return requestContext;
+  }
+
+  @Override
+  protected void customizeParSeqRestliClient(ParSeqRestliClientBuilder parSeqRestliClientBuilder) {
+    parSeqRestliClientBuilder.setRequestContextProvider(this::createRequestContext);
+  }
+
+  @Test
+  public void testNonBatchableRequest() {
+    try {
+      GetRequest<Greeting> request = new GreetingsBuilders().get().id(1L).build();
+      Task<?> task = _parseqClient.createTask(request);
+      runAndWait(getTestClassName() + ".testNonBatchableRequest", task);
+      verifyRequestContext(request);
+    } finally {
+      _capturingRestClient.clearCapturedRequestContexts();
+    }
+  }
+
+  @Test
+  public void testBatchableRequestNotBatched() {
+    try {
+      setInboundRequestContext(new InboundRequestContextBuilder()
+          .setName("withBatching")
+          .build());
+      GetRequest<Greeting> request = new GreetingsBuilders().get().id(1L).build();
+      Task<?> task = _parseqClient.createTask(request);
+      runAndWait(getTestClassName() + ".testNonBatchableRequest", task);
+      verifyRequestContext(request);
+    } finally {
+      _capturingRestClient.clearCapturedRequestContexts();
+    }
+  }
+
+  @Test
+  public void testBatchableRequestBatched() {
+    try {
+      setInboundRequestContext(new InboundRequestContextBuilder()
+          .setName("withBatching")
+          .build());
+      GetRequest<Greeting> request1 = new GreetingsBuilders().get().id(1L).build();
+      GetRequest<Greeting> request2 = new GreetingsBuilders().get().id(2L).build();
+      Task<?> task = Task.par(_parseqClient.createTask(request1), _parseqClient.createTask(request2));
+
+      runAndWait(getTestClassName() + ".testNonBatchableRequest", task);
+
+      Collection<RequestContext> contexts = _capturingRestClient.getCapturedRequestContexts().values();
+      assertEquals(contexts.size(), 1);
+      RequestContext context = contexts.iterator().next();
+      assertNotNull(context.getLocalAttr("method"));
+      assertEquals(context.getLocalAttr("method"), ResourceMethod.BATCH_GET);
+
+    } finally {
+      _capturingRestClient.clearCapturedRequestContexts();
+    }
+  }
+
+  private void verifyRequestContext(Request<?> request) {
+    assertTrue(_capturingRestClient.getCapturedRequestContexts().containsKey(request));
+    assertNotNull(_capturingRestClient.getCapturedRequestContexts().get(request).getLocalAttr("method"));
+    assertEquals(_capturingRestClient.getCapturedRequestContexts().get(request).getLocalAttr("method"), request.getMethod());
+  }
+
+  @Test
+  public void testConfiguredTimeoutOutboundOverride() {
+      Task<?> task = greetingGet(1L, new RequestConfigOverridesBuilder()
+          .setTimeoutMs(5555L, "overriden")
+          .build());
+      runAndWait(getTestClassName() + ".testConfiguredTimeoutOutbound", task);
+      assertTrue(hasTask("withTimeout 5555ms src: overriden", task.getTrace()));
+  }
+
+  @Test
+  public void testConfiguredTimeoutOutboundOverrideNoSrc() {
+      Task<?> task = greetingGet(1L, new RequestConfigOverridesBuilder()
+          .setTimeoutMs(5555L)
+          .build());
+      runAndWait(getTestClassName() + ".testConfiguredTimeoutOutbound", task);
+      assertTrue(hasTask("withTimeout 5555ms", task.getTrace()));
+  }
+
+  @Test
+  public void testConfiguredTimeoutInboundAndOutbound() {
+    try {
+      setInboundRequestContext(new InboundRequestContextBuilder()
+          .setName("foo")
+          .setMethod("GET")
+          .build());
+      Task<?> task = greetingGet(1L);
+      runAndWait(getTestClassName() + ".testConfiguredTimeoutInboundAndOutbound", task);
+      assertTrue(hasTask("withTimeout 10004ms src: foo.GET/greetings.GET", task.getTrace()));
+    } finally {
+      clearInboundRequestContext();
+    }
+  }
+
+  @Test
+  public void testConfiguredTimeoutMismatchedInboundOutbound() {
+    try {
+      setInboundRequestContext(new InboundRequestContextBuilder()
+          .setName("blah")
+          .setMethod("GET")
+          .build());
+      Task<?> task = greetingGet(1L);
+      runAndWait(getTestClassName() + ".testConfiguredTimeoutMismatchedInboundOutbound", task);
+      assertTrue(hasTask("withTimeout 9999ms src: *.*/greetings.GET", task.getTrace()));
+    } finally {
+      clearInboundRequestContext();
+    }
+  }
+
+  @Test
+  public void testConfiguredTimeoutFullActionAndOutbound() {
+    try {
+      setInboundRequestContext(new InboundRequestContextBuilder()
+          .setName("foo")
+          .setMethod("ACTION")
+          .setActionName("bar")
+          .build());
+      Task<?> task = greetingGet(1L);
+      runAndWait(getTestClassName() + ".testConfiguredTimeoutFullActionAndOutbound", task);
+      assertTrue(hasTask("withTimeout 10006ms src: foo.ACTION-bar/greetings.GET", task.getTrace()));
+    } finally {
+      clearInboundRequestContext();
+    }
+  }
+
+  @Test
+  public void testConfiguredTimeoutPartialActionAndOutbound() {
+    try {
+      setInboundRequestContext(new InboundRequestContextBuilder()
+          .setName("foo")
+          .setMethod("ACTION")
+          .build());
+      Task<?> task = greetingGet(1L);
+      runAndWait(getTestClassName() + ".testConfiguredTimeoutPartialActionAndOutbound", task);
+      assertTrue(hasTask("withTimeout 10005ms src: foo.ACTION-*/greetings.GET", task.getTrace()));
+    } finally {
+      clearInboundRequestContext();
+    }
+  }
+
+  @Test
+  public void testConfiguredTimeoutOutboundOp() {
+    try {
+      setInboundRequestContext(new InboundRequestContextBuilder()
+          .setName("blah")
+          .setMethod("GET")
+          .build());
+      Task<?> task = greetingDel(9999L).toTry();
+      runAndWait(getTestClassName() + ".testConfiguredTimeoutOutboundOp", task);
+      assertTrue(hasTask("withTimeout 10001ms src: *.*/greetings.*", task.getTrace()));
+    } finally {
+      clearInboundRequestContext();
+    }
+  }
+
+  @Test
+  public void testBatchingGetRequests() {
+    try {
+      setInboundRequestContext(new InboundRequestContextBuilder()
+          .setName("withBatching")
+          .build());
+      Task<?> task = Task.par(greetingGet(1L), greetingGet(2L), greetingGet(3L));
+      runAndWait(getTestClassName() + ".testBatchingGetRequests", task);
+      assertTrue(hasTask("greetings batch_get(reqs: 3, ids: 3)", task.getTrace()));
+    } finally {
+      clearInboundRequestContext();
+    }
+  }
+
+  @Test
+  public void testBatchingGetRequestsMaxExceeded() {
+    try {
+      setInboundRequestContext(new InboundRequestContextBuilder()
+          .setName("withBatching")
+          .build());
+      Task<?> task = Task.par(greetingGet(1L), greetingGet(2L), greetingGet(3L), greetingGet(4L));
+      runAndWait(getTestClassName() + ".testBatchingGetRequestsMaxExceeded", task);
+      assertTrue(hasTask("greetings batch_get(reqs: 3, ids: 3)", task.getTrace()));
+    } finally {
+      clearInboundRequestContext();
+    }
+  }
+
+  @Test
+  public void testBatchGetLargerThanMaxBatchSize() {
+    try {
+      setInboundRequestContext(new InboundRequestContextBuilder()
+          .setName("withBatching")
+          .build());
+      Task<?> task = greetings(1L, 2L, 3L, 4L);
+      runAndWait(getTestClassName() + ".testBatchGetLargerThanMaxBatchSize", task);
+      assertFalse(hasTask("greetings batch_get(reqs: 3, ids: 3)", task.getTrace()));
+    } finally {
+      clearInboundRequestContext();
+    }
+  }
+
+}


### PR DESCRIPTION
RequestContext provider is a function that takes Request<?> object and
returns RequestContext object. It is used to create RequestContext
object in case when caller did not provide one as a parameter.

This change is backwards compatible. Up until now the implicit
RequestContext provider was: () -> new RequestContext() and it is now
explicit.