### PR TITLE
Unbatch complex keys fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v2.6.8
+------
+
+* Fixed unbatching various types of BATCH_GET requests from BATCH_GET for complex keys.
+
 v2.6.7
 ------
 

--- a/contrib/parseq-batching/pom.xml
+++ b/contrib/parseq-batching/pom.xml
@@ -4,13 +4,13 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.linkedin.parseq</groupId>
     <artifactId>parseq-batching</artifactId>
-    <version>2.6.7</version>
+    <version>2.6.8</version>
 
     <dependencies>
         <dependency>
             <groupId>com.linkedin.parseq</groupId>
             <artifactId>parseq</artifactId>
-            <version>2.6.7</version>
+            <version>2.6.8</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.linkedin.parseq</groupId>
             <artifactId>parseq</artifactId>
-            <version>2.6.7</version>
+            <version>2.6.8</version>
             <classifier>test</classifier>
             <scope>test</scope>
         </dependency>

--- a/contrib/parseq-benchmark/pom.xml
+++ b/contrib/parseq-benchmark/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.linkedin.parseq</groupId>
     <artifactId>parseq-benchmark</artifactId>
-    <version>2.6.7</version>
+    <version>2.6.8</version>
     <packaging>jar</packaging>
 
     <prerequisites>
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.linkedin.parseq</groupId>
             <artifactId>parseq</artifactId>
-            <version>2.6.7</version>
+            <version>2.6.8</version>
         </dependency>
     </dependencies>
 

--- a/contrib/parseq-examples/pom.xml
+++ b/contrib/parseq-examples/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.linkedin.parseq</groupId>
     <artifactId>parseq-examples</artifactId>
-    <version>2.6.7</version>
+    <version>2.6.8</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -14,17 +14,17 @@
         <dependency>
             <groupId>com.linkedin.parseq</groupId>
             <artifactId>parseq</artifactId>
-            <version>2.6.7</version>
+            <version>2.6.8</version>
         </dependency>
         <dependency>
             <groupId>com.linkedin.parseq</groupId>
             <artifactId>parseq-http-client</artifactId>
-            <version>2.6.7</version>
+            <version>2.6.8</version>
         </dependency>
         <dependency>
             <groupId>com.linkedin.parseq</groupId>
             <artifactId>parseq-batching</artifactId>
-            <version>2.6.7</version>
+            <version>2.6.8</version>
         </dependency>
     </dependencies>
 

--- a/contrib/parseq-exec/pom.xml
+++ b/contrib/parseq-exec/pom.xml
@@ -4,13 +4,13 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.linkedin.parseq</groupId>
     <artifactId>parseq-exec</artifactId>
-    <version>2.6.7</version>
+    <version>2.6.8</version>
 
     <dependencies>
         <dependency>
             <groupId>com.linkedin.parseq</groupId>
             <artifactId>parseq</artifactId>
-            <version>2.6.7</version>
+            <version>2.6.8</version>
         </dependency>
     </dependencies>
 

--- a/contrib/parseq-http-client/pom.xml
+++ b/contrib/parseq-http-client/pom.xml
@@ -4,13 +4,13 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.linkedin.parseq</groupId>
     <artifactId>parseq-http-client</artifactId>
-    <version>2.6.7</version>
+    <version>2.6.8</version>
 
     <dependencies>
         <dependency>
             <groupId>com.linkedin.parseq</groupId>
             <artifactId>parseq</artifactId>
-            <version>2.6.7</version>
+            <version>2.6.8</version>
         </dependency>
         <dependency>
             <groupId>com.ning</groupId>

--- a/contrib/parseq-legacy-examples/pom.xml
+++ b/contrib/parseq-legacy-examples/pom.xml
@@ -4,13 +4,13 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.linkedin.parseq</groupId>
     <artifactId>parseq-legacy-examples</artifactId>
-    <version>2.6.7</version>
+    <version>2.6.8</version>
 
     <dependencies>
         <dependency>
             <groupId>com.linkedin.parseq</groupId>
             <artifactId>parseq</artifactId>
-            <version>2.6.7</version>
+            <version>2.6.8</version>
         </dependency>
     </dependencies>
 

--- a/contrib/parseq-restli-client/pom.xml
+++ b/contrib/parseq-restli-client/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.linkedin.parseq</groupId>
     <artifactId>parseq-restli-client</artifactId>
-    <version>2.6.7</version>
+    <version>2.6.8</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -14,12 +14,12 @@
         <dependency>
             <groupId>com.linkedin.parseq</groupId>
             <artifactId>parseq</artifactId>
-            <version>2.6.7</version>
+            <version>2.6.8</version>
         </dependency>
         <dependency>
             <groupId>com.linkedin.parseq</groupId>
             <artifactId>parseq-batching</artifactId>
-            <version>2.6.7</version>
+            <version>2.6.8</version>
         </dependency>
         <dependency>
             <groupId>com.linkedin.pegasus</groupId>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.linkedin.parseq</groupId>
             <artifactId>parseq</artifactId>
-            <version>2.6.7</version>
+            <version>2.6.8</version>
             <classifier>test</classifier>
             <scope>test</scope>
         </dependency>

--- a/contrib/parseq-tracevis-server/pom.xml
+++ b/contrib/parseq-tracevis-server/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.linkedin.parseq</groupId>
   <artifactId>parseq-tracevis-server</artifactId>
-  <version>2.6.7</version>
+  <version>2.6.8</version>
   <packaging>jar</packaging>
 
   <properties>
@@ -26,22 +26,22 @@
 		<dependency>
 			<groupId>com.linkedin.parseq</groupId>
 			<artifactId>parseq</artifactId>
-			<version>2.6.7</version>
+			<version>2.6.8</version>
 		</dependency>
 		<dependency>
 			<groupId>com.linkedin.parseq</groupId>
 			<artifactId>parseq-exec</artifactId>
-			<version>2.6.7</version>
+			<version>2.6.8</version>
 		</dependency>
         <dependency>
             <groupId>com.linkedin.parseq</groupId>
             <artifactId>parseq-http-client</artifactId>
-            <version>2.6.7</version>
+            <version>2.6.8</version>
         </dependency>
 		<dependency>
 			<groupId>com.linkedin.parseq</groupId>
 			<artifactId>parseq-tracevis</artifactId>
-			<version>2.6.7</version>
+			<version>2.6.8</version>
 			<type>tar.gz</type>
 		</dependency>
 		<dependency>

--- a/contrib/parseq-zk-client/pom.xml
+++ b/contrib/parseq-zk-client/pom.xml
@@ -4,13 +4,13 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.linkedin.parseq</groupId>
     <artifactId>parseq-zk-client</artifactId>
-    <version>2.6.7</version>
+    <version>2.6.8</version>
 
     <dependencies>
         <dependency>
             <groupId>com.linkedin.parseq</groupId>
             <artifactId>parseq</artifactId>
-            <version>2.6.7</version>
+            <version>2.6.8</version>
         </dependency>
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.linkedin.parseq</groupId>
             <artifactId>parseq</artifactId>
-            <version>2.6.7</version>
+            <version>2.6.8</version>
             <classifier>test</classifier>
             <scope>test</scope>
         </dependency>

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=2.6.7
+version=2.6.8


### PR DESCRIPTION
The change is primarily replacing:
        Set<String> ids = rrbk.ids();
with:
        Set<String> ids = (Set<String>) request.getObjectIds().stream()
            .map(o -> BatchResponse.keyToString(o, version))
            .collect(Collectors.toSet());
The second form handles complex keys correctly.
The rest of this change is refactoring of onSuccess() to split it into smaller methods.