### PR TITLE
Deprecate Tasks.par(...) for safer alternative Task.par(...) that does not throw IllegalArgumentException on empty collection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v2.6.9
+------
+
+* Deprecate Tasks.par(...) for safer alternative Task.par(...) that does not throw IllegalArgumentException on empty collection.
+
 v2.6.8
 ------
 

--- a/src/com/linkedin/parseq/ParTaskImpl.java
+++ b/src/com/linkedin/parseq/ParTaskImpl.java
@@ -66,12 +66,11 @@ import java.util.List;
 
   @Override
   protected Promise<List<T>> run(final Context context) throws Exception {
-    final SettablePromise<List<T>> result = Promises.settable();
-
     if (_tasks.isEmpty()) {
-      result.done(Collections.<T>emptyList());
-      return result;
+      return Promises.value(Collections.<T>emptyList());
     }
+
+    final SettablePromise<List<T>> result = Promises.settable();
 
     final PromiseListener<?> listener = new PromiseListener<Object>() {
       @Override

--- a/src/com/linkedin/parseq/ParTaskImpl.java
+++ b/src/com/linkedin/parseq/ParTaskImpl.java
@@ -41,6 +41,11 @@ import java.util.List;
 /* package private */ class ParTaskImpl<T> extends BaseTask<List<T>>implements ParTask<T> {
   private final List<Task<T>> _tasks;
 
+  public ParTaskImpl(final String name) {
+    super(name);
+    _tasks = Collections.emptyList();
+  }
+
   public ParTaskImpl(final String name, final Iterable<? extends Task<? extends T>> tasks) {
     super(name);
     List<Task<T>> taskList = new ArrayList<Task<T>>();
@@ -62,6 +67,11 @@ import java.util.List;
   @Override
   protected Promise<List<T>> run(final Context context) throws Exception {
     final SettablePromise<List<T>> result = Promises.settable();
+
+    if (_tasks.isEmpty()) {
+      result.done(Collections.<T>emptyList());
+      return result;
+    }
 
     final PromiseListener<?> listener = new PromiseListener<Object>() {
       @Override

--- a/src/com/linkedin/parseq/Task.java
+++ b/src/com/linkedin/parseq/Task.java
@@ -1406,6 +1406,30 @@ public interface Task<T> extends Promise<T>, Cancellable {
   }
 
   /**
+   * Creates a new task that will run each of the supplied tasks in parallel (e.g.
+   * tasks[0] can be run at the same time as tasks[1]).
+   * <p>
+   * When all tasks complete successfully, you can use
+   * {@link com.linkedin.parseq.ParTask#get()} to get a list of the results. If
+   * at least one task failed, then this task will also be marked as failed. Use
+   * {@link com.linkedin.parseq.ParTask#getTasks()} or
+   * {@link com.linkedin.parseq.ParTask#getSuccessful()} to get results in this
+   * case.
+   * <p>
+   * Note that resulting task does not fast-fail e.g. if one of the tasks fail others
+   * are not cancelled. This is different behavior than {@link Task#par(Task, Task)} where
+   * resulting task fast-fails.
+   *
+   * @param tasks the tasks to run in parallel
+   * @return The results of the tasks
+   */
+  public static <T> ParTask<T> par(final Iterable<? extends Task<? extends T>> tasks) {
+    return tasks.iterator().hasNext()
+        ? new ParTaskImpl<T>("par", tasks)
+        : new ParTaskImpl<T>("par");
+  }
+
+  /**
    * Equivalent to {@code withRetryPolicy("operation", policy, taskSupplier)}.
    * @see #withRetryPolicy(String, RetryPolicy, Callable)
    */

--- a/src/com/linkedin/parseq/Task.java
+++ b/src/com/linkedin/parseq/Task.java
@@ -1416,6 +1416,9 @@ public interface Task<T> extends Promise<T>, Cancellable {
    * {@link com.linkedin.parseq.ParTask#getSuccessful()} to get results in this
    * case.
    * <p>
+   * If the Iterable of tasks is empty, {@link com.linkedin.parseq.ParTask#get()}
+   * will return an empty list.
+   * <p>
    * Note that resulting task does not fast-fail e.g. if one of the tasks fail others
    * are not cancelled. This is different behavior than {@link Task#par(Task, Task)} where
    * resulting task fast-fails.

--- a/src/com/linkedin/parseq/Tasks.java
+++ b/src/com/linkedin/parseq/Tasks.java
@@ -351,24 +351,10 @@ public class Tasks {
   }
 
   /**
-   * Creates a new task that will run each of the supplied tasks in parallel (e.g.
-   * tasks[0] can be run at the same time as tasks[1]). This is a type-safe,
-   * collection-based alternative to {@link #vapar(Task[])}.
-   * <p>
-   * When all tasks complete successfully, you can use
-   * {@link com.linkedin.parseq.ParTask#get()} to get a list of the results. If
-   * at least one task failed, then this task will also be marked as failed. Use
-   * {@link com.linkedin.parseq.ParTask#getTasks()} or
-   * {@link com.linkedin.parseq.ParTask#getSuccessful()} to get results in this
-   * case.
-   * <p>
-   * Note that resulting task does not fast-fail e.g. if one of the tasks fail others
-   * are not cancelled. This is different behavior than {@link Task#par(Task, Task)} where
-   * resulting task fast-fails.
-   *
-   * @param tasks the tasks to run in parallel
-   * @return The results of the tasks
+   * @deprecated  As of 2.0.0, replaced by {@link Task#par(Iterable) Task.par}
+   * @see Task#par(Iterable) Task.par
    */
+  @Deprecated
   public static <T> ParTask<T> par(final Iterable<? extends Task<? extends T>> tasks) {
     return new ParTaskImpl<T>("par", tasks);
   }

--- a/src/com/linkedin/parseq/Tasks.java
+++ b/src/com/linkedin/parseq/Tasks.java
@@ -352,6 +352,8 @@ public class Tasks {
 
   /**
    * @deprecated  As of 2.0.0, replaced by {@link Task#par(Iterable) Task.par}
+   * as a safer alternative that does not throw an IllegalArgumentException for
+   * an empty Iterable of tasks.
    * @see Task#par(Iterable) Task.par
    */
   @Deprecated

--- a/test/com/linkedin/parseq/TestTaskFactoryMethods.java
+++ b/test/com/linkedin/parseq/TestTaskFactoryMethods.java
@@ -4,6 +4,9 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -635,5 +638,30 @@ public class TestTaskFactoryMethods extends BaseEngineTest {
     assertEquals((int)task.get(), 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9);
 
     assertEquals(countTasks(task.getTrace()), 2 + 3 + 9);
+  }
+
+  @Test
+  public void testPar() {
+    List<Task<Integer>> tasks = new ArrayList<Task<Integer>>();
+    tasks.add(Task.value(1));
+    tasks.add(Task.value(2));
+    tasks.add(Task.value(3));
+
+    ParTask<Integer> task = Task.par(tasks);
+    runAndWait("TestTaskFactoryMethods.testPar", task);
+    assertEquals(task.get().stream().mapToInt(Integer::intValue).sum(), 1 + 2 + 3);
+
+    assertEquals(countTasks(task.getTrace()), 3 + 1);
+  }
+
+  @Test
+  public void testParEmpty() {
+    List<Task<Integer>> tasks = Collections.emptyList();
+
+    ParTask<Integer> task = Task.par(tasks);
+    runAndWait("TestTaskFactoryMethods.testParEmpty", task);
+    assertEquals(task.get().stream().mapToInt(Integer::intValue).sum(), 0);
+
+    assertEquals(countTasks(task.getTrace()), 1);
   }
 }


### PR DESCRIPTION
Deprecate Tasks.par(...) for safer alternative Task.par(...) that does not throw IllegalArgumentException on empty collection.