### PR TITLE
Enable automatic cross-thread stack tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ v2.6.9
 ------
 
 * Deprecate Tasks.par(...) for safer alternative Task.par(...) that does not throw IllegalArgumentException on empty collection.
+* Enable automatic cross-thread stack tracing
 
 v2.6.8
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ v2.6.9
 ------
 
 * Deprecate Tasks.par(...) for safer alternative Task.par(...) that does not throw IllegalArgumentException on empty collection.
-* Enable automatic cross-thread stack tracing
+* Enable automatic cross-thread stack tracing. It is an optional feature, turned off by default. See `ParSeqGlobalConfiguration.setCrossThreadStackTracesEnabled()`.
 
 v2.6.8
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v2.6.9
+------
+
+* Deprecate Tasks.par(...) for safer alternative Task.par(...) that does not throw IllegalArgumentException on empty collection.
+
 v2.6.8
 ------
 

--- a/src/com/linkedin/parseq/BaseTask.java
+++ b/src/com/linkedin/parseq/BaseTask.java
@@ -127,7 +127,7 @@ public abstract class BaseTask<T> extends DelegatingPromise<T>implements Task<T>
     }
     _stateRef = new AtomicReference<>(state);
 
-    if (ParSeqGlobalConfiguration.getInstance().isCrossThreadStackTracesEnabled()) {
+    if (ParSeqGlobalConfiguration.isCrossThreadStackTracesEnabled()) {
       _taskStackTrace = Thread.currentThread().getStackTrace();
     } else {
       _taskStackTrace = null;
@@ -329,7 +329,9 @@ public abstract class BaseTask<T> extends DelegatingPromise<T>implements Task<T>
 
   // Concatenate stack traces if kept the original stack trace from the task creation
   private void appendTaskStackTrace(final Throwable error) {
-    if (!ParSeqGlobalConfiguration.getInstance().isCrossThreadStackTracesEnabled() || error == null ||
+    // At a minimum, any stack trace should have at least 3 stack frames (caller + BaseTask + getStackTrace).
+    // So if there are less than 3 stack frames available then there's something fishy and it's better to ignore them.
+    if (!ParSeqGlobalConfiguration.isCrossThreadStackTracesEnabled() || error == null ||
         _taskStackTrace == null || _taskStackTrace.length <= 2) {
       return;
     }

--- a/src/com/linkedin/parseq/BaseTask.java
+++ b/src/com/linkedin/parseq/BaseTask.java
@@ -51,6 +51,7 @@ public abstract class BaseTask<T> extends DelegatingPromise<T>implements Task<T>
   private static final int TASK_NAME_MAX_LENGTH = 1024;
 
   static final Logger LOGGER = LoggerFactory.getLogger(BaseTask.class);
+  private static final String CANONICAL_NAME = BaseTask.class.getCanonicalName();
 
   private static enum StateType {
     // The initial state of the task.
@@ -88,6 +89,8 @@ public abstract class BaseTask<T> extends DelegatingPromise<T>implements Task<T>
 
   private volatile TraceBuilder _traceBuilder;
 
+  private final StackTraceElement[] _taskStackTrace;
+
   /**
    * Constructs a base task without a specified name. The name for this task
    * will be the {@link #toString} representation for this instance. It is
@@ -113,7 +116,7 @@ public abstract class BaseTask<T> extends DelegatingPromise<T>implements Task<T>
    * @param taskType the type of the task
    */
   public BaseTask(final String name, final String taskType) {
-    super(Promises.<T> settable());
+    super(Promises.settable());
     _name = truncate(name);
     final State state = State.INIT;
     _shallowTraceBuilder = new ShallowTraceBuilder(_id);
@@ -122,7 +125,8 @@ public abstract class BaseTask<T> extends DelegatingPromise<T>implements Task<T>
     if (taskType != null) {
       _shallowTraceBuilder.setTaskType(taskType);
     }
-    _stateRef = new AtomicReference<State>(state);
+    _stateRef = new AtomicReference<>(state);
+    _taskStackTrace = Thread.currentThread().getStackTrace();
   }
 
   private String truncate(String name) {
@@ -311,10 +315,66 @@ public abstract class BaseTask<T> extends DelegatingPromise<T>implements Task<T>
 
   private void fail(final Throwable error, final TaskLogger taskLogger) {
     if (transitionDone()) {
+      appendTaskStackTrace(error);
       traceFailure(error);
       getSettableDelegate().fail(error);
       taskLogger.logTaskEnd(BaseTask.this, _traceValueProvider);
     }
+  }
+
+  // Concatenate stack traces if kept the original stack trace from the task creation
+  private void appendTaskStackTrace(final Throwable error) {
+    if (_taskStackTrace == null || _taskStackTrace.length <= 2) {
+      return;
+    }
+
+    StackTraceElement[] errorStackTrace = error.getStackTrace();
+    if (errorStackTrace.length <= 2) {
+      return;
+    }
+
+    // Skip stack frames up to the BaseTask (useless java.util.concurrent stuff)
+    int skipErrorFrames = 1;
+    while (skipErrorFrames < errorStackTrace.length) {
+      int index = errorStackTrace.length - 1 - skipErrorFrames;
+      if (!errorStackTrace[index].getClassName().equals(CANONICAL_NAME) &&
+          errorStackTrace[index + 1].getClassName().equals(CANONICAL_NAME)) {
+        break;
+      }
+      skipErrorFrames++;
+    }
+
+    // Safeguard against accidentally removing entire stack trace
+    if (skipErrorFrames == errorStackTrace.length) {
+      skipErrorFrames = 0;
+    }
+
+    // Skip stack frames up to the BaseTask (useless Thread.getStackTrace stuff)
+    int skipTaskFrames = 1;
+    while (skipTaskFrames < _taskStackTrace.length) {
+      if (!_taskStackTrace[skipTaskFrames].getClassName().equals(CANONICAL_NAME) &&
+          _taskStackTrace[skipTaskFrames - 1].getClassName().equals(CANONICAL_NAME)) {
+        break;
+      }
+      skipTaskFrames++;
+    }
+
+    // Safeguard against accidentally removing entire stack trace
+    if (skipTaskFrames == _taskStackTrace.length) {
+      skipTaskFrames = 0;
+    }
+
+    int combinedLength = errorStackTrace.length - skipErrorFrames + _taskStackTrace.length - skipTaskFrames;
+    if (combinedLength <= 0) {
+      return;
+    }
+
+    StackTraceElement[] concatenatedStackTrace = new StackTraceElement[combinedLength];
+    System.arraycopy(errorStackTrace, 0, concatenatedStackTrace,
+        0, errorStackTrace.length - skipErrorFrames);
+    System.arraycopy(_taskStackTrace, skipTaskFrames, concatenatedStackTrace,
+        errorStackTrace.length - skipErrorFrames, _taskStackTrace.length - skipTaskFrames);
+    error.setStackTrace(concatenatedStackTrace);
   }
 
   protected boolean transitionRun(final TraceBuilder traceBuilder) {

--- a/src/com/linkedin/parseq/ParSeqGlobalConfiguration.java
+++ b/src/com/linkedin/parseq/ParSeqGlobalConfiguration.java
@@ -1,19 +1,29 @@
-package com.linkedin.parseq;
+/*
+ * Copyright 2012 LinkedIn, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 
-import java.util.concurrent.atomic.AtomicBoolean;
+package com.linkedin.parseq;
 
 
 /**
  * Global parseq configuration, applies to all Engine and Task instances
+ *
+ * @author Oleg Anashkin (oanashkin@linkedin.com)
  */
-public class ParSeqGlobalConfiguration {
-  private static final ParSeqGlobalConfiguration _instance = new ParSeqGlobalConfiguration();
-
-  private AtomicBoolean _crossThreadStackTracesEnabled = new AtomicBoolean(false);
-
-  public static ParSeqGlobalConfiguration getInstance() {
-    return _instance;
-  }
+public final class ParSeqGlobalConfiguration {
+  private static volatile boolean _crossThreadStackTracesEnabled = false;
 
   private ParSeqGlobalConfiguration() {
   }
@@ -21,30 +31,31 @@ public class ParSeqGlobalConfiguration {
   /**
    * Returns current state of cross-thread (cross-task) stack tracing.
    *
-   * Normally tasks are executed in different thread from the one creating it and at a different time. This makes it
-   * hard to debug because if task throws an exception, its call stack ends in the execution engine that actually
+   * Normally tasks are executed in a different thread from the one creating it and at a different time. This makes it
+   * hard to debug because if a task throws an exception, its call stack ends in the execution engine that actually
    * starts a thread that serves the task. This feature collects stack trace in advance, when task is created, so that
-   * if the task throws the exception then the parent stack trace is appended to it. This has a small performance
-   * impact even if the task doesn't throw any exception because stack trace is collected in task constructor.
+   * if a task throws an exception then the parent stack trace is appended to it. This has a small performance
+   * impact even if the task doesn't throw any exceptions because stack trace is collected in task constructor.
    *
    * @return true if cross-thread stack tracing is enabled, false otherwise
    */
-  public boolean isCrossThreadStackTracesEnabled() {
-    return _crossThreadStackTracesEnabled.get();
+  public static boolean isCrossThreadStackTracesEnabled() {
+    return _crossThreadStackTracesEnabled;
   }
 
   /**
    * Modifies the current state of cross-thread (cross-task) stack tracing.
+   * This is a dynamic runtime configuration that has immediate effect on all tasks in the current process.
    *
-   * Normally tasks are executed in different thread from the one creating it and at a different time. This makes it
-   * hard to debug because if task throws an exception, its call stack ends in the execution engine that actually
+   * Normally tasks are executed in a different thread from the one creating it and at a different time. This makes it
+   * hard to debug because if a task throws an exception, its call stack ends in the execution engine that actually
    * starts a thread that serves the task. This feature collects stack trace in advance, when task is created, so that
-   * if the task throws the exception then the parent stack trace is appended to it. This has a small performance
-   * impact even if the task doesn't throw any exception because stack trace is collected in task constructor.
+   * if a task throws an exception then the parent stack trace is appended to it. This has a small performance
+   * impact even if the task doesn't throw any exceptions because stack trace is collected in task constructor.
    *
    * @param enabled true if cross-thread stack tracing is enabled, false otherwise
    */
-  public void setCrossThreadStackTracesEnabled(boolean enabled) {
-    _crossThreadStackTracesEnabled.set(enabled);
+  public static void setCrossThreadStackTracesEnabled(boolean enabled) {
+    _crossThreadStackTracesEnabled = enabled;
   }
 }

--- a/src/com/linkedin/parseq/ParSeqGlobalConfiguration.java
+++ b/src/com/linkedin/parseq/ParSeqGlobalConfiguration.java
@@ -1,0 +1,50 @@
+package com.linkedin.parseq;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+
+/**
+ * Global parseq configuration, applies to all Engine and Task instances
+ */
+public class ParSeqGlobalConfiguration {
+  private static final ParSeqGlobalConfiguration _instance = new ParSeqGlobalConfiguration();
+
+  private AtomicBoolean _crossThreadStackTracesEnabled = new AtomicBoolean(false);
+
+  public static ParSeqGlobalConfiguration getInstance() {
+    return _instance;
+  }
+
+  private ParSeqGlobalConfiguration() {
+  }
+
+  /**
+   * Returns current state of cross-thread (cross-task) stack tracing.
+   *
+   * Normally tasks are executed in different thread from the one creating it and at a different time. This makes it
+   * hard to debug because if task throws an exception, its call stack ends in the execution engine that actually
+   * starts a thread that serves the task. This feature collects stack trace in advance, when task is created, so that
+   * if the task throws the exception then the parent stack trace is appended to it. This has a small performance
+   * impact even if the task doesn't throw any exception because stack trace is collected in task constructor.
+   *
+   * @return true if cross-thread stack tracing is enabled, false otherwise
+   */
+  public boolean isCrossThreadStackTracesEnabled() {
+    return _crossThreadStackTracesEnabled.get();
+  }
+
+  /**
+   * Modifies the current state of cross-thread (cross-task) stack tracing.
+   *
+   * Normally tasks are executed in different thread from the one creating it and at a different time. This makes it
+   * hard to debug because if task throws an exception, its call stack ends in the execution engine that actually
+   * starts a thread that serves the task. This feature collects stack trace in advance, when task is created, so that
+   * if the task throws the exception then the parent stack trace is appended to it. This has a small performance
+   * impact even if the task doesn't throw any exception because stack trace is collected in task constructor.
+   *
+   * @param enabled true if cross-thread stack tracing is enabled, false otherwise
+   */
+  public void setCrossThreadStackTracesEnabled(boolean enabled) {
+    _crossThreadStackTracesEnabled.set(enabled);
+  }
+}

--- a/src/com/linkedin/parseq/ParTaskImpl.java
+++ b/src/com/linkedin/parseq/ParTaskImpl.java
@@ -41,6 +41,11 @@ import java.util.List;
 /* package private */ class ParTaskImpl<T> extends BaseTask<List<T>>implements ParTask<T> {
   private final List<Task<T>> _tasks;
 
+  public ParTaskImpl(final String name) {
+    super(name);
+    _tasks = Collections.emptyList();
+  }
+
   public ParTaskImpl(final String name, final Iterable<? extends Task<? extends T>> tasks) {
     super(name);
     List<Task<T>> taskList = new ArrayList<Task<T>>();
@@ -61,6 +66,10 @@ import java.util.List;
 
   @Override
   protected Promise<List<T>> run(final Context context) throws Exception {
+    if (_tasks.isEmpty()) {
+      return Promises.value(Collections.<T>emptyList());
+    }
+
     final SettablePromise<List<T>> result = Promises.settable();
 
     final PromiseListener<?> listener = new PromiseListener<Object>() {

--- a/src/com/linkedin/parseq/Task.java
+++ b/src/com/linkedin/parseq/Task.java
@@ -1406,6 +1406,33 @@ public interface Task<T> extends Promise<T>, Cancellable {
   }
 
   /**
+   * Creates a new task that will run each of the supplied tasks in parallel (e.g.
+   * tasks[0] can be run at the same time as tasks[1]).
+   * <p>
+   * When all tasks complete successfully, you can use
+   * {@link com.linkedin.parseq.ParTask#get()} to get a list of the results. If
+   * at least one task failed, then this task will also be marked as failed. Use
+   * {@link com.linkedin.parseq.ParTask#getTasks()} or
+   * {@link com.linkedin.parseq.ParTask#getSuccessful()} to get results in this
+   * case.
+   * <p>
+   * If the Iterable of tasks is empty, {@link com.linkedin.parseq.ParTask#get()}
+   * will return an empty list.
+   * <p>
+   * Note that resulting task does not fast-fail e.g. if one of the tasks fail others
+   * are not cancelled. This is different behavior than {@link Task#par(Task, Task)} where
+   * resulting task fast-fails.
+   *
+   * @param tasks the tasks to run in parallel
+   * @return The results of the tasks
+   */
+  public static <T> ParTask<T> par(final Iterable<? extends Task<? extends T>> tasks) {
+    return tasks.iterator().hasNext()
+        ? new ParTaskImpl<T>("par", tasks)
+        : new ParTaskImpl<T>("par");
+  }
+
+  /**
    * Equivalent to {@code withRetryPolicy("operation", policy, taskSupplier)}.
    * @see #withRetryPolicy(String, RetryPolicy, Callable)
    */

--- a/src/com/linkedin/parseq/Tasks.java
+++ b/src/com/linkedin/parseq/Tasks.java
@@ -351,24 +351,12 @@ public class Tasks {
   }
 
   /**
-   * Creates a new task that will run each of the supplied tasks in parallel (e.g.
-   * tasks[0] can be run at the same time as tasks[1]). This is a type-safe,
-   * collection-based alternative to {@link #vapar(Task[])}.
-   * <p>
-   * When all tasks complete successfully, you can use
-   * {@link com.linkedin.parseq.ParTask#get()} to get a list of the results. If
-   * at least one task failed, then this task will also be marked as failed. Use
-   * {@link com.linkedin.parseq.ParTask#getTasks()} or
-   * {@link com.linkedin.parseq.ParTask#getSuccessful()} to get results in this
-   * case.
-   * <p>
-   * Note that resulting task does not fast-fail e.g. if one of the tasks fail others
-   * are not cancelled. This is different behavior than {@link Task#par(Task, Task)} where
-   * resulting task fast-fails.
-   *
-   * @param tasks the tasks to run in parallel
-   * @return The results of the tasks
+   * @deprecated  As of 2.0.0, replaced by {@link Task#par(Iterable) Task.par}
+   * as a safer alternative that does not throw an IllegalArgumentException for
+   * an empty Iterable of tasks.
+   * @see Task#par(Iterable) Task.par
    */
+  @Deprecated
   public static <T> ParTask<T> par(final Iterable<? extends Task<? extends T>> tasks) {
     return new ParTaskImpl<T>("par", tasks);
   }

--- a/test/com/linkedin/parseq/TestTask.java
+++ b/test/com/linkedin/parseq/TestTask.java
@@ -1,8 +1,11 @@
 package com.linkedin.parseq;
 
 import com.linkedin.parseq.promise.Promises;
+import java.util.Arrays;
 import java.util.concurrent.TimeoutException;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
 
 
 /**
@@ -91,6 +94,18 @@ public class TestTask extends AbstractTaskTest {
     testOnFailureWhenCancelled(3);
   }
 
+  @Test
+  public void testStackFrames() {
+    Task<String> failureTask = getFailureTask();
+    try {
+      runAndWait("TestTask.testStackFrames", failureTask);
+      fail("should have failed");
+    } catch (Exception ex) {
+      ex.getCause().printStackTrace(System.out);
+      assertFalse(Arrays.toString(ex.getStackTrace()).contains("BaseTask"));
+    }
+  }
+
   @Override
   Task<String> getSuccessTask() {
     return Task.async("success", () -> Promises.value(TASK_VALUE));
@@ -107,5 +122,6 @@ public class TestTask extends AbstractTaskTest {
   Task<String> getCancelledTask() {
     return Task.async("cancelled", () -> {
       throw new CancellationException(new TimeoutException());
-    });  }
+    });
+  }
 }

--- a/test/com/linkedin/parseq/TestTask.java
+++ b/test/com/linkedin/parseq/TestTask.java
@@ -20,13 +20,13 @@ public class TestTask extends AbstractTaskTest {
 
   @BeforeClass
   public void start() {
-    _crossThreadStackTracesEnabled = ParSeqGlobalConfiguration.getInstance().isCrossThreadStackTracesEnabled();
-    ParSeqGlobalConfiguration.getInstance().setCrossThreadStackTracesEnabled(true);
+    _crossThreadStackTracesEnabled = ParSeqGlobalConfiguration.isCrossThreadStackTracesEnabled();
+    ParSeqGlobalConfiguration.setCrossThreadStackTracesEnabled(true);
   }
 
   @AfterClass
   public void stop() {
-    ParSeqGlobalConfiguration.getInstance().setCrossThreadStackTracesEnabled(_crossThreadStackTracesEnabled);
+    ParSeqGlobalConfiguration.setCrossThreadStackTracesEnabled(_crossThreadStackTracesEnabled);
   }
 
   @Test

--- a/test/com/linkedin/parseq/TestTaskFactoryMethods.java
+++ b/test/com/linkedin/parseq/TestTaskFactoryMethods.java
@@ -4,6 +4,9 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -635,5 +638,30 @@ public class TestTaskFactoryMethods extends BaseEngineTest {
     assertEquals((int)task.get(), 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9);
 
     assertEquals(countTasks(task.getTrace()), 2 + 3 + 9);
+  }
+
+  @Test
+  public void testPar() {
+    List<Task<Integer>> tasks = new ArrayList<Task<Integer>>();
+    tasks.add(Task.value(1));
+    tasks.add(Task.value(2));
+    tasks.add(Task.value(3));
+
+    ParTask<Integer> task = Task.par(tasks);
+    runAndWait("TestTaskFactoryMethods.testPar", task);
+    assertEquals(task.get().stream().mapToInt(Integer::intValue).sum(), 1 + 2 + 3);
+
+    assertEquals(countTasks(task.getTrace()), 3 + 1);
+  }
+
+  @Test
+  public void testParEmpty() {
+    List<Task<Integer>> tasks = Collections.emptyList();
+
+    ParTask<Integer> task = Task.par(tasks);
+    runAndWait("TestTaskFactoryMethods.testParEmpty", task);
+    assertEquals(task.get().stream().mapToInt(Integer::intValue).sum(), 0);
+
+    assertEquals(countTasks(task.getTrace()), 1);
   }
 }


### PR DESCRIPTION
Normally tasks are executed in a different thread from the one creating it and at a different time. This makes it hard to debug because when a task throws an exception its call stack ends in the execution engine that actually starts a thread that serves the task. This feature collects task's stack trace in advance, when task is created, so that if the task throws the exception then the parent stack trace is appended to it. This has a small performance impact even if the task doesn't throw any exception because stack trace is collected in task constructor.

Stack trace before:

```
java.lang.RuntimeException: error
  at com.linkedin.parseq.TestTask.lambda$getFailureTask$2(TestTask.java:135)
  at com.linkedin.parseq.TestTask$$Lambda$91/209387180.call(Unknown Source)
  at com.linkedin.parseq.Task.lambda$async$20(Task.java:1060)
  at com.linkedin.parseq.Task$$Lambda$32/1381965390.apply(Unknown Source)
  at com.linkedin.parseq.Task$1.run(Task.java:1097)
  at com.linkedin.parseq.BaseTask.doContextRun(BaseTask.java:232)
  at com.linkedin.parseq.BaseTask.contextRun(BaseTask.java:200)
  at com.linkedin.parseq.internal.ContextImpl$2.run(ContextImpl.java:93)
  at com.linkedin.parseq.internal.SerialExecutor$ExecutorLoop.run(SerialExecutor.java:121)
  at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
  at java.util.concurrent.FutureTask.run(FutureTask.java:266)
  at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
  at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
  at java.lang.Thread.run(Thread.java:745)
```

Stack trace after:

```
java.lang.RuntimeException: error
  at com.linkedin.parseq.TestTask.lambda$getFailureTask$2(TestTask.java:135)
  at com.linkedin.parseq.TestTask$$Lambda$91/833726670.call(Unknown Source)
  at com.linkedin.parseq.Task.lambda$async$20(Task.java:1060)
  at com.linkedin.parseq.Task$$Lambda$32/1381965390.apply(Unknown Source)
  at com.linkedin.parseq.Task$1.run(Task.java:1097)
  at ********** Task "failure" (above) was instantiated as following (below): **********.(Unknown Source)
  at com.linkedin.parseq.Task$1.<init>(Task.java:1094)
  at com.linkedin.parseq.Task.async(Task.java:1094)
  at com.linkedin.parseq.Task.async(Task.java:1058)
  at com.linkedin.parseq.TestTask.getFailureTask(TestTask.java:134)
  at com.linkedin.parseq.TestTask.lambda$testStackFrames$0(TestTask.java:116)
  at com.linkedin.parseq.TestTask$$Lambda$95/1205406622.apply(Unknown Source)
  at com.linkedin.parseq.promise.PromiseTransformer.accept(PromiseTransformer.java:34)
  at com.linkedin.parseq.promise.PromiseTransformer.accept(PromiseTransformer.java:6)
  at com.linkedin.parseq.FusionTask.lambda$adaptToAcceptTraceContext$0(FusionTask.java:73)
  at com.linkedin.parseq.FusionTask$$Lambda$6/878274034.accept(Unknown Source)
  at com.linkedin.parseq.FusionTask.lambda$completing$3(FusionTask.java:175)
  at com.linkedin.parseq.FusionTask$$Lambda$7/1296674576.accept(Unknown Source)
  at com.linkedin.parseq.FusionTask.propagate(FusionTask.java:321)
  at com.linkedin.parseq.FusionTask.lambda$run$6(FusionTask.java:342)
  at com.linkedin.parseq.FusionTask$$Lambda$21/2049720174.apply(Unknown Source)
  at com.linkedin.parseq.Task$1.run(Task.java:1097)
  at ********** Task "nested" (above) was instantiated as following (below): **********.(Unknown Source)
  at com.linkedin.parseq.Task$1.<init>(Task.java:1094)
  at com.linkedin.parseq.Task.async(Task.java:1094)
  at com.linkedin.parseq.Task.flatten(Task.java:829)
  at com.linkedin.parseq.Task.flatMap(Task.java:232)
  at com.linkedin.parseq.TestTask.testStackFrames(TestTask.java:116)
  at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.lang.reflect.Method.invoke(Method.java:497)
  at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:85)
  at org.testng.internal.Invoker.invokeMethod(Invoker.java:639)
  at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:816)
  at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1124)
  at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:125)
  at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:108)
  at org.testng.TestRunner.privateRun(TestRunner.java:774)
  at org.testng.TestRunner.run(TestRunner.java:624)
  at org.testng.SuiteRunner.runTest(SuiteRunner.java:359)
  at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:354)
  at org.testng.SuiteRunner.privateRun(SuiteRunner.java:312)
  at org.testng.SuiteRunner.run(SuiteRunner.java:261)
  at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
  at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
  at org.testng.TestNG.runSuitesSequentially(TestNG.java:1215)
  at org.testng.TestNG.runSuitesLocally(TestNG.java:1140)
  at org.testng.TestNG.run(TestNG.java:1048)
  at org.testng.TestNG.privateMain(TestNG.java:1355)
  at org.testng.TestNG.main(TestNG.java:1324)
```