### PR TITLE
Optimize task stack trace collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v2.6.11
+------
+* Significantly reduce Task creation overhead when cross-thread stack tracing is enabled.
+
 v2.6.10
 ------
 

--- a/src/com/linkedin/parseq/BaseTask.java
+++ b/src/com/linkedin/parseq/BaseTask.java
@@ -89,7 +89,7 @@ public abstract class BaseTask<T> extends DelegatingPromise<T>implements Task<T>
 
   private volatile TraceBuilder _traceBuilder;
 
-  private final StackTraceElement[] _taskStackTrace;
+  private final Throwable _taskStackTraceHolder;
 
   /**
    * Constructs a base task without a specified name. The name for this task
@@ -128,9 +128,9 @@ public abstract class BaseTask<T> extends DelegatingPromise<T>implements Task<T>
     _stateRef = new AtomicReference<>(state);
 
     if (ParSeqGlobalConfiguration.isCrossThreadStackTracesEnabled()) {
-      _taskStackTrace = Thread.currentThread().getStackTrace();
+      _taskStackTraceHolder = new Throwable();
     } else {
-      _taskStackTrace = null;
+      _taskStackTraceHolder = null;
     }
   }
 
@@ -329,10 +329,12 @@ public abstract class BaseTask<T> extends DelegatingPromise<T>implements Task<T>
 
   // Concatenate stack traces if kept the original stack trace from the task creation
   private void appendTaskStackTrace(final Throwable error) {
+    StackTraceElement[] taskStackTrace = this._taskStackTraceHolder != null ? this._taskStackTraceHolder.getStackTrace() : null;
+
     // At a minimum, any stack trace should have at least 3 stack frames (caller + BaseTask + getStackTrace).
     // So if there are less than 3 stack frames available then there's something fishy and it's better to ignore them.
     if (!ParSeqGlobalConfiguration.isCrossThreadStackTracesEnabled() || error == null ||
-        _taskStackTrace == null || _taskStackTrace.length <= 2) {
+        taskStackTrace == null || taskStackTrace.length <= 2) {
       return;
     }
 
@@ -359,20 +361,20 @@ public abstract class BaseTask<T> extends DelegatingPromise<T>implements Task<T>
 
     // Skip stack frames up to the BaseTask (useless Thread.getStackTrace stuff)
     int skipTaskFrames = 1;
-    while (skipTaskFrames < _taskStackTrace.length) {
-      if (!_taskStackTrace[skipTaskFrames].getClassName().equals(CANONICAL_NAME) &&
-          _taskStackTrace[skipTaskFrames - 1].getClassName().equals(CANONICAL_NAME)) {
+    while (skipTaskFrames < taskStackTrace.length) {
+      if (!taskStackTrace[skipTaskFrames].getClassName().equals(CANONICAL_NAME) &&
+          taskStackTrace[skipTaskFrames - 1].getClassName().equals(CANONICAL_NAME)) {
         break;
       }
       skipTaskFrames++;
     }
 
     // Safeguard against accidentally removing entire stack trace
-    if (skipTaskFrames == _taskStackTrace.length) {
+    if (skipTaskFrames == taskStackTrace.length) {
       skipTaskFrames = 0;
     }
 
-    int combinedLength = errorStackTrace.length - skipErrorFrames + _taskStackTrace.length - skipTaskFrames;
+    int combinedLength = errorStackTrace.length - skipErrorFrames + taskStackTrace.length - skipTaskFrames;
     if (combinedLength <= 0) {
       return;
     }
@@ -382,8 +384,8 @@ public abstract class BaseTask<T> extends DelegatingPromise<T>implements Task<T>
         0, errorStackTrace.length - skipErrorFrames);
     concatenatedStackTrace[errorStackTrace.length - skipErrorFrames] =
         new StackTraceElement("********** Task \"" + getName() + "\" (above) was instantiated as following (below): **********", "",null, 0);
-    System.arraycopy(_taskStackTrace, skipTaskFrames, concatenatedStackTrace,
-        errorStackTrace.length - skipErrorFrames + 1, _taskStackTrace.length - skipTaskFrames);
+    System.arraycopy(taskStackTrace, skipTaskFrames, concatenatedStackTrace,
+        errorStackTrace.length - skipErrorFrames + 1, taskStackTrace.length - skipTaskFrames);
     error.setStackTrace(concatenatedStackTrace);
   }
 

--- a/src/com/linkedin/parseq/BaseTask.java
+++ b/src/com/linkedin/parseq/BaseTask.java
@@ -329,7 +329,7 @@ public abstract class BaseTask<T> extends DelegatingPromise<T>implements Task<T>
 
   // Concatenate stack traces if kept the original stack trace from the task creation
   private void appendTaskStackTrace(final Throwable error) {
-    StackTraceElement[] taskStackTrace = this._taskStackTraceHolder != null ? this._taskStackTraceHolder.getStackTrace() : null;
+    StackTraceElement[] taskStackTrace = _taskStackTraceHolder != null ? _taskStackTraceHolder.getStackTrace() : null;
 
     // At a minimum, any stack trace should have at least 3 stack frames (caller + BaseTask + getStackTrace).
     // So if there are less than 3 stack frames available then there's something fishy and it's better to ignore them.


### PR DESCRIPTION
It turns out according to benchmarks that creating temporary exception object is approximately 10x faster than collecting the full stack trace by calling `Thread.getStackTrace()`. The reason is explained in https://stackoverflow.com/questions/26116181/access-stacktraces-with-good-performance - basically, collecting takes only 10% and the rest 90% is spent on converting it into a readable format. Since creating Throwable by itself doesn't do any conversion, it ends up being 10x faster.