### PR TITLE
Use typesafe method to build projection.

### DIFF
--- a/contrib/parseq-restli-client/src/main/java/com/linkedin/restli/client/GetRequestGroup.java
+++ b/contrib/parseq-restli-client/src/main/java/com/linkedin/restli/client/GetRequestGroup.java
@@ -313,7 +313,7 @@ class GetRequestGroup implements RequestGroup {
 
     builder.id((K) ids.iterator().next());
     if (fields != null && !fields.isEmpty()) {
-      builder.setParam(RestConstants.FIELDS_PARAM, fields.toArray());
+      builder.fields(fields.toArray(new PathSpec[fields.size()]));
     }
 
     final GetRequest<RT> get = builder.build();

--- a/contrib/parseq-restli-client/src/test/java/com/linkedin/restli/client/ParSeqRestClientBatchingIntegrationTest.java
+++ b/contrib/parseq-restli-client/src/test/java/com/linkedin/restli/client/ParSeqRestClientBatchingIntegrationTest.java
@@ -394,6 +394,14 @@ public abstract class ParSeqRestClientBatchingIntegrationTest extends ParSeqRest
   }
 
   @Test
+  public void testSingleGetRequestIsNotBatchedWithProjection() {
+    Task<Boolean> task = greetingGetWithProjection(1L, Greeting.fields().tone()).map(Response::getEntity).map(Greeting::hasMessage);
+    runAndWait(getTestClassName() + ".testSingleGetRequestIsNotBatchedWithProjection", task);
+    assertFalse(hasTask("greetings batch_get(reqs: 1, ids: 1)", task.getTrace()));
+    assertFalse(task.get());
+  }
+
+  @Test
   public void testDuplicateGetRequestIsNotBatched() {
     Task<?> task = Task.par(greetingGet(1L), greetingGet(1L));
     runAndWait(getTestClassName() + ".testDuplicateGetRequestIsNotBatched", task);


### PR DESCRIPTION
Fix another projection building in doExecuteGet.