### PR TITLE
fix Tuple*Task.java javadoc's image not showing bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+v2.6.35
+------
+
+* Remove .DS_Store file and improve javadoc for Task.par.
+* Fix Tuple*Task.java javadoc's image not showing bug 
+
 v2.6.34
 ------
 
@@ -8,7 +14,6 @@ v2.6.33
 
 * Allow - in parent resource name in parseq-restli-client configuration for cross-center calls.
 * Add Zookeeper ACL support
-
 
 v2.6.32
 ------

--- a/fmpp/templates/com/linkedin/parseq/TupleNTask.java.ftl
+++ b/fmpp/templates/com/linkedin/parseq/TupleNTask.java.ftl
@@ -31,7 +31,7 @@ public interface Tuple${i}Task<<@typeParameters i/>> extends Task<Tuple${i}<<@ty
    * // this task will complete with value 11
    * Task{@code <Integer>} length = hello.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task is completed with an exception then the new task will also complete
    * with that exception.
@@ -43,7 +43,7 @@ public interface Tuple${i}Task<<@typeParameters i/>> extends Task<Tuple${i}<<@ty
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <Integer>} length = failing.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
@@ -73,7 +73,7 @@ public interface Tuple${i}Task<<@typeParameters i/>> extends Task<Tuple${i}<<@ty
    *  // assuming fetch(u) fetches contents given by a URI
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    *
    * If this task is completed with an exception then the new task will also contain
@@ -84,7 +84,7 @@ public interface Tuple${i}Task<<@typeParameters i/>> extends Task<Tuple${i}<<@ty
    *  // this task will fail with java.lang.IllegalArgumentException
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-2.png" type="image/svg+xml" height="90px"/>
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
    * @param f function to be applied to successful result of this task which returns new task
@@ -115,7 +115,7 @@ public interface Tuple${i}Task<<@typeParameters i/>> extends Task<Tuple${i}<<@ty
    *  // this task will print "Hello World"
    *  Task{@code <String>} sayHello = hello.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task fails then consumer will not be called and failure
    * will be propagated to task returned by this method.
@@ -127,7 +127,7 @@ public interface Tuple${i}Task<<@typeParameters i/>> extends Task<Tuple${i}<<@ty
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <String>} sayHello = failing.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param desc description of a consumer, it will show up in a trace
    * @param consumer consumer of a value returned by this task
@@ -231,7 +231,7 @@ public interface Tuple${i}Task<<@typeParameters i/>> extends Task<Tuple${i}<<@ty
    *  Task{@code <String>} userName = id.flatMap("fetch", u {@code ->} fetch(u))
    *      .withSideEffect("update memcache", u {@code ->} updateMemcache(u));
    * </pre></blockquote>
-   * <img src="doc-files/withSideEffect-1.svg" type="image/svg+xml" height="120px"/>
+   * <img src="doc-files/withSideEffect-1.png" type="image/svg+xml" height="120px"/>
    *
    * @param desc description of a side effect, it will show up in a trace
    * @param func function to be applied on result of successful completion of this task

--- a/src/com/linkedin/parseq/Tuple10Task.java
+++ b/src/com/linkedin/parseq/Tuple10Task.java
@@ -27,7 +27,7 @@ public interface Tuple10Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Ta
    * // this task will complete with value 11
    * Task{@code <Integer>} length = hello.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task is completed with an exception then the new task will also complete
    * with that exception.
@@ -39,7 +39,7 @@ public interface Tuple10Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Ta
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <Integer>} length = failing.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
@@ -69,7 +69,7 @@ public interface Tuple10Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Ta
    *  // assuming fetch(u) fetches contents given by a URI
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    *
    * If this task is completed with an exception then the new task will also contain
@@ -80,7 +80,7 @@ public interface Tuple10Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Ta
    *  // this task will fail with java.lang.IllegalArgumentException
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-2.png" type="image/svg+xml" height="90px"/>
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
    * @param f function to be applied to successful result of this task which returns new task
@@ -111,7 +111,7 @@ public interface Tuple10Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Ta
    *  // this task will print "Hello World"
    *  Task{@code <String>} sayHello = hello.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task fails then consumer will not be called and failure
    * will be propagated to task returned by this method.
@@ -123,7 +123,7 @@ public interface Tuple10Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Ta
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <String>} sayHello = failing.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param desc description of a consumer, it will show up in a trace
    * @param consumer consumer of a value returned by this task
@@ -227,7 +227,7 @@ public interface Tuple10Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Ta
    *  Task{@code <String>} userName = id.flatMap("fetch", u {@code ->} fetch(u))
    *      .withSideEffect("update memcache", u {@code ->} updateMemcache(u));
    * </pre></blockquote>
-   * <img src="doc-files/withSideEffect-1.svg" type="image/svg+xml" height="120px"/>
+   * <img src="doc-files/withSideEffect-1.png" type="image/svg+xml" height="120px"/>
    *
    * @param desc description of a side effect, it will show up in a trace
    * @param func function to be applied on result of successful completion of this task

--- a/src/com/linkedin/parseq/Tuple11Task.java
+++ b/src/com/linkedin/parseq/Tuple11Task.java
@@ -27,7 +27,7 @@ public interface Tuple11Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> exten
    * // this task will complete with value 11
    * Task{@code <Integer>} length = hello.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task is completed with an exception then the new task will also complete
    * with that exception.
@@ -39,7 +39,7 @@ public interface Tuple11Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> exten
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <Integer>} length = failing.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
@@ -69,7 +69,7 @@ public interface Tuple11Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> exten
    *  // assuming fetch(u) fetches contents given by a URI
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    *
    * If this task is completed with an exception then the new task will also contain
@@ -80,7 +80,7 @@ public interface Tuple11Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> exten
    *  // this task will fail with java.lang.IllegalArgumentException
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-2.png" type="image/svg+xml" height="90px"/>
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
    * @param f function to be applied to successful result of this task which returns new task
@@ -111,7 +111,7 @@ public interface Tuple11Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> exten
    *  // this task will print "Hello World"
    *  Task{@code <String>} sayHello = hello.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task fails then consumer will not be called and failure
    * will be propagated to task returned by this method.
@@ -123,7 +123,7 @@ public interface Tuple11Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> exten
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <String>} sayHello = failing.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param desc description of a consumer, it will show up in a trace
    * @param consumer consumer of a value returned by this task
@@ -227,7 +227,7 @@ public interface Tuple11Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> exten
    *  Task{@code <String>} userName = id.flatMap("fetch", u {@code ->} fetch(u))
    *      .withSideEffect("update memcache", u {@code ->} updateMemcache(u));
    * </pre></blockquote>
-   * <img src="doc-files/withSideEffect-1.svg" type="image/svg+xml" height="120px"/>
+   * <img src="doc-files/withSideEffect-1.png" type="image/svg+xml" height="120px"/>
    *
    * @param desc description of a side effect, it will show up in a trace
    * @param func function to be applied on result of successful completion of this task

--- a/src/com/linkedin/parseq/Tuple12Task.java
+++ b/src/com/linkedin/parseq/Tuple12Task.java
@@ -27,7 +27,7 @@ public interface Tuple12Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> 
    * // this task will complete with value 11
    * Task{@code <Integer>} length = hello.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task is completed with an exception then the new task will also complete
    * with that exception.
@@ -39,7 +39,7 @@ public interface Tuple12Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> 
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <Integer>} length = failing.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
@@ -69,7 +69,7 @@ public interface Tuple12Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> 
    *  // assuming fetch(u) fetches contents given by a URI
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    *
    * If this task is completed with an exception then the new task will also contain
@@ -80,7 +80,7 @@ public interface Tuple12Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> 
    *  // this task will fail with java.lang.IllegalArgumentException
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-2.png" type="image/svg+xml" height="90px"/>
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
    * @param f function to be applied to successful result of this task which returns new task
@@ -111,7 +111,7 @@ public interface Tuple12Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> 
    *  // this task will print "Hello World"
    *  Task{@code <String>} sayHello = hello.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task fails then consumer will not be called and failure
    * will be propagated to task returned by this method.
@@ -123,7 +123,7 @@ public interface Tuple12Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> 
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <String>} sayHello = failing.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param desc description of a consumer, it will show up in a trace
    * @param consumer consumer of a value returned by this task
@@ -227,7 +227,7 @@ public interface Tuple12Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> 
    *  Task{@code <String>} userName = id.flatMap("fetch", u {@code ->} fetch(u))
    *      .withSideEffect("update memcache", u {@code ->} updateMemcache(u));
    * </pre></blockquote>
-   * <img src="doc-files/withSideEffect-1.svg" type="image/svg+xml" height="120px"/>
+   * <img src="doc-files/withSideEffect-1.png" type="image/svg+xml" height="120px"/>
    *
    * @param desc description of a side effect, it will show up in a trace
    * @param func function to be applied on result of successful completion of this task

--- a/src/com/linkedin/parseq/Tuple13Task.java
+++ b/src/com/linkedin/parseq/Tuple13Task.java
@@ -27,7 +27,7 @@ public interface Tuple13Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
    * // this task will complete with value 11
    * Task{@code <Integer>} length = hello.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task is completed with an exception then the new task will also complete
    * with that exception.
@@ -39,7 +39,7 @@ public interface Tuple13Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <Integer>} length = failing.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
@@ -69,7 +69,7 @@ public interface Tuple13Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
    *  // assuming fetch(u) fetches contents given by a URI
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    *
    * If this task is completed with an exception then the new task will also contain
@@ -80,7 +80,7 @@ public interface Tuple13Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
    *  // this task will fail with java.lang.IllegalArgumentException
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-2.png" type="image/svg+xml" height="90px"/>
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
    * @param f function to be applied to successful result of this task which returns new task
@@ -111,7 +111,7 @@ public interface Tuple13Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
    *  // this task will print "Hello World"
    *  Task{@code <String>} sayHello = hello.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task fails then consumer will not be called and failure
    * will be propagated to task returned by this method.
@@ -123,7 +123,7 @@ public interface Tuple13Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <String>} sayHello = failing.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param desc description of a consumer, it will show up in a trace
    * @param consumer consumer of a value returned by this task
@@ -227,7 +227,7 @@ public interface Tuple13Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
    *  Task{@code <String>} userName = id.flatMap("fetch", u {@code ->} fetch(u))
    *      .withSideEffect("update memcache", u {@code ->} updateMemcache(u));
    * </pre></blockquote>
-   * <img src="doc-files/withSideEffect-1.svg" type="image/svg+xml" height="120px"/>
+   * <img src="doc-files/withSideEffect-1.png" type="image/svg+xml" height="120px"/>
    *
    * @param desc description of a side effect, it will show up in a trace
    * @param func function to be applied on result of successful completion of this task

--- a/src/com/linkedin/parseq/Tuple14Task.java
+++ b/src/com/linkedin/parseq/Tuple14Task.java
@@ -27,7 +27,7 @@ public interface Tuple14Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
    * // this task will complete with value 11
    * Task{@code <Integer>} length = hello.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task is completed with an exception then the new task will also complete
    * with that exception.
@@ -39,7 +39,7 @@ public interface Tuple14Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <Integer>} length = failing.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
@@ -69,7 +69,7 @@ public interface Tuple14Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
    *  // assuming fetch(u) fetches contents given by a URI
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    *
    * If this task is completed with an exception then the new task will also contain
@@ -80,7 +80,7 @@ public interface Tuple14Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
    *  // this task will fail with java.lang.IllegalArgumentException
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-2.png" type="image/svg+xml" height="90px"/>
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
    * @param f function to be applied to successful result of this task which returns new task
@@ -111,7 +111,7 @@ public interface Tuple14Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
    *  // this task will print "Hello World"
    *  Task{@code <String>} sayHello = hello.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task fails then consumer will not be called and failure
    * will be propagated to task returned by this method.
@@ -123,7 +123,7 @@ public interface Tuple14Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <String>} sayHello = failing.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param desc description of a consumer, it will show up in a trace
    * @param consumer consumer of a value returned by this task
@@ -227,7 +227,7 @@ public interface Tuple14Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
    *  Task{@code <String>} userName = id.flatMap("fetch", u {@code ->} fetch(u))
    *      .withSideEffect("update memcache", u {@code ->} updateMemcache(u));
    * </pre></blockquote>
-   * <img src="doc-files/withSideEffect-1.svg" type="image/svg+xml" height="120px"/>
+   * <img src="doc-files/withSideEffect-1.png" type="image/svg+xml" height="120px"/>
    *
    * @param desc description of a side effect, it will show up in a trace
    * @param func function to be applied on result of successful completion of this task

--- a/src/com/linkedin/parseq/Tuple15Task.java
+++ b/src/com/linkedin/parseq/Tuple15Task.java
@@ -27,7 +27,7 @@ public interface Tuple15Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
    * // this task will complete with value 11
    * Task{@code <Integer>} length = hello.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task is completed with an exception then the new task will also complete
    * with that exception.
@@ -39,7 +39,7 @@ public interface Tuple15Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <Integer>} length = failing.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
@@ -69,7 +69,7 @@ public interface Tuple15Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
    *  // assuming fetch(u) fetches contents given by a URI
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    *
    * If this task is completed with an exception then the new task will also contain
@@ -80,7 +80,7 @@ public interface Tuple15Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
    *  // this task will fail with java.lang.IllegalArgumentException
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-2.png" type="image/svg+xml" height="90px"/>
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
    * @param f function to be applied to successful result of this task which returns new task
@@ -111,7 +111,7 @@ public interface Tuple15Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
    *  // this task will print "Hello World"
    *  Task{@code <String>} sayHello = hello.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task fails then consumer will not be called and failure
    * will be propagated to task returned by this method.
@@ -123,7 +123,7 @@ public interface Tuple15Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <String>} sayHello = failing.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param desc description of a consumer, it will show up in a trace
    * @param consumer consumer of a value returned by this task
@@ -227,7 +227,7 @@ public interface Tuple15Task<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, 
    *  Task{@code <String>} userName = id.flatMap("fetch", u {@code ->} fetch(u))
    *      .withSideEffect("update memcache", u {@code ->} updateMemcache(u));
    * </pre></blockquote>
-   * <img src="doc-files/withSideEffect-1.svg" type="image/svg+xml" height="120px"/>
+   * <img src="doc-files/withSideEffect-1.png" type="image/svg+xml" height="120px"/>
    *
    * @param desc description of a side effect, it will show up in a trace
    * @param func function to be applied on result of successful completion of this task

--- a/src/com/linkedin/parseq/Tuple2Task.java
+++ b/src/com/linkedin/parseq/Tuple2Task.java
@@ -27,7 +27,7 @@ public interface Tuple2Task<T1, T2> extends Task<Tuple2<T1, T2>> {
    * // this task will complete with value 11
    * Task{@code <Integer>} length = hello.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task is completed with an exception then the new task will also complete
    * with that exception.
@@ -39,7 +39,7 @@ public interface Tuple2Task<T1, T2> extends Task<Tuple2<T1, T2>> {
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <Integer>} length = failing.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
@@ -69,7 +69,7 @@ public interface Tuple2Task<T1, T2> extends Task<Tuple2<T1, T2>> {
    *  // assuming fetch(u) fetches contents given by a URI
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    *
    * If this task is completed with an exception then the new task will also contain
@@ -80,7 +80,7 @@ public interface Tuple2Task<T1, T2> extends Task<Tuple2<T1, T2>> {
    *  // this task will fail with java.lang.IllegalArgumentException
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-2.png" type="image/svg+xml" height="90px"/>
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
    * @param f function to be applied to successful result of this task which returns new task
@@ -111,7 +111,7 @@ public interface Tuple2Task<T1, T2> extends Task<Tuple2<T1, T2>> {
    *  // this task will print "Hello World"
    *  Task{@code <String>} sayHello = hello.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task fails then consumer will not be called and failure
    * will be propagated to task returned by this method.
@@ -123,7 +123,7 @@ public interface Tuple2Task<T1, T2> extends Task<Tuple2<T1, T2>> {
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <String>} sayHello = failing.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param desc description of a consumer, it will show up in a trace
    * @param consumer consumer of a value returned by this task
@@ -227,7 +227,7 @@ public interface Tuple2Task<T1, T2> extends Task<Tuple2<T1, T2>> {
    *  Task{@code <String>} userName = id.flatMap("fetch", u {@code ->} fetch(u))
    *      .withSideEffect("update memcache", u {@code ->} updateMemcache(u));
    * </pre></blockquote>
-   * <img src="doc-files/withSideEffect-1.svg" type="image/svg+xml" height="120px"/>
+   * <img src="doc-files/withSideEffect-1.png" type="image/svg+xml" height="120px"/>
    *
    * @param desc description of a side effect, it will show up in a trace
    * @param func function to be applied on result of successful completion of this task

--- a/src/com/linkedin/parseq/Tuple3Task.java
+++ b/src/com/linkedin/parseq/Tuple3Task.java
@@ -27,7 +27,7 @@ public interface Tuple3Task<T1, T2, T3> extends Task<Tuple3<T1, T2, T3>> {
    * // this task will complete with value 11
    * Task{@code <Integer>} length = hello.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task is completed with an exception then the new task will also complete
    * with that exception.
@@ -39,7 +39,7 @@ public interface Tuple3Task<T1, T2, T3> extends Task<Tuple3<T1, T2, T3>> {
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <Integer>} length = failing.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
@@ -69,7 +69,7 @@ public interface Tuple3Task<T1, T2, T3> extends Task<Tuple3<T1, T2, T3>> {
    *  // assuming fetch(u) fetches contents given by a URI
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    *
    * If this task is completed with an exception then the new task will also contain
@@ -80,7 +80,7 @@ public interface Tuple3Task<T1, T2, T3> extends Task<Tuple3<T1, T2, T3>> {
    *  // this task will fail with java.lang.IllegalArgumentException
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-2.png" type="image/svg+xml" height="90px"/>
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
    * @param f function to be applied to successful result of this task which returns new task
@@ -111,7 +111,7 @@ public interface Tuple3Task<T1, T2, T3> extends Task<Tuple3<T1, T2, T3>> {
    *  // this task will print "Hello World"
    *  Task{@code <String>} sayHello = hello.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task fails then consumer will not be called and failure
    * will be propagated to task returned by this method.
@@ -123,7 +123,7 @@ public interface Tuple3Task<T1, T2, T3> extends Task<Tuple3<T1, T2, T3>> {
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <String>} sayHello = failing.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param desc description of a consumer, it will show up in a trace
    * @param consumer consumer of a value returned by this task
@@ -227,7 +227,7 @@ public interface Tuple3Task<T1, T2, T3> extends Task<Tuple3<T1, T2, T3>> {
    *  Task{@code <String>} userName = id.flatMap("fetch", u {@code ->} fetch(u))
    *      .withSideEffect("update memcache", u {@code ->} updateMemcache(u));
    * </pre></blockquote>
-   * <img src="doc-files/withSideEffect-1.svg" type="image/svg+xml" height="120px"/>
+   * <img src="doc-files/withSideEffect-1.png" type="image/svg+xml" height="120px"/>
    *
    * @param desc description of a side effect, it will show up in a trace
    * @param func function to be applied on result of successful completion of this task

--- a/src/com/linkedin/parseq/Tuple4Task.java
+++ b/src/com/linkedin/parseq/Tuple4Task.java
@@ -27,7 +27,7 @@ public interface Tuple4Task<T1, T2, T3, T4> extends Task<Tuple4<T1, T2, T3, T4>>
    * // this task will complete with value 11
    * Task{@code <Integer>} length = hello.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task is completed with an exception then the new task will also complete
    * with that exception.
@@ -39,7 +39,7 @@ public interface Tuple4Task<T1, T2, T3, T4> extends Task<Tuple4<T1, T2, T3, T4>>
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <Integer>} length = failing.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
@@ -69,7 +69,7 @@ public interface Tuple4Task<T1, T2, T3, T4> extends Task<Tuple4<T1, T2, T3, T4>>
    *  // assuming fetch(u) fetches contents given by a URI
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    *
    * If this task is completed with an exception then the new task will also contain
@@ -80,7 +80,7 @@ public interface Tuple4Task<T1, T2, T3, T4> extends Task<Tuple4<T1, T2, T3, T4>>
    *  // this task will fail with java.lang.IllegalArgumentException
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-2.png" type="image/svg+xml" height="90px"/>
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
    * @param f function to be applied to successful result of this task which returns new task
@@ -111,7 +111,7 @@ public interface Tuple4Task<T1, T2, T3, T4> extends Task<Tuple4<T1, T2, T3, T4>>
    *  // this task will print "Hello World"
    *  Task{@code <String>} sayHello = hello.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task fails then consumer will not be called and failure
    * will be propagated to task returned by this method.
@@ -123,7 +123,7 @@ public interface Tuple4Task<T1, T2, T3, T4> extends Task<Tuple4<T1, T2, T3, T4>>
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <String>} sayHello = failing.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param desc description of a consumer, it will show up in a trace
    * @param consumer consumer of a value returned by this task
@@ -227,7 +227,7 @@ public interface Tuple4Task<T1, T2, T3, T4> extends Task<Tuple4<T1, T2, T3, T4>>
    *  Task{@code <String>} userName = id.flatMap("fetch", u {@code ->} fetch(u))
    *      .withSideEffect("update memcache", u {@code ->} updateMemcache(u));
    * </pre></blockquote>
-   * <img src="doc-files/withSideEffect-1.svg" type="image/svg+xml" height="120px"/>
+   * <img src="doc-files/withSideEffect-1.png" type="image/svg+xml" height="120px"/>
    *
    * @param desc description of a side effect, it will show up in a trace
    * @param func function to be applied on result of successful completion of this task

--- a/src/com/linkedin/parseq/Tuple5Task.java
+++ b/src/com/linkedin/parseq/Tuple5Task.java
@@ -27,7 +27,7 @@ public interface Tuple5Task<T1, T2, T3, T4, T5> extends Task<Tuple5<T1, T2, T3, 
    * // this task will complete with value 11
    * Task{@code <Integer>} length = hello.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task is completed with an exception then the new task will also complete
    * with that exception.
@@ -39,7 +39,7 @@ public interface Tuple5Task<T1, T2, T3, T4, T5> extends Task<Tuple5<T1, T2, T3, 
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <Integer>} length = failing.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
@@ -69,7 +69,7 @@ public interface Tuple5Task<T1, T2, T3, T4, T5> extends Task<Tuple5<T1, T2, T3, 
    *  // assuming fetch(u) fetches contents given by a URI
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    *
    * If this task is completed with an exception then the new task will also contain
@@ -80,7 +80,7 @@ public interface Tuple5Task<T1, T2, T3, T4, T5> extends Task<Tuple5<T1, T2, T3, 
    *  // this task will fail with java.lang.IllegalArgumentException
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-2.png" type="image/svg+xml" height="90px"/>
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
    * @param f function to be applied to successful result of this task which returns new task
@@ -111,7 +111,7 @@ public interface Tuple5Task<T1, T2, T3, T4, T5> extends Task<Tuple5<T1, T2, T3, 
    *  // this task will print "Hello World"
    *  Task{@code <String>} sayHello = hello.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task fails then consumer will not be called and failure
    * will be propagated to task returned by this method.
@@ -123,7 +123,7 @@ public interface Tuple5Task<T1, T2, T3, T4, T5> extends Task<Tuple5<T1, T2, T3, 
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <String>} sayHello = failing.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param desc description of a consumer, it will show up in a trace
    * @param consumer consumer of a value returned by this task
@@ -227,7 +227,7 @@ public interface Tuple5Task<T1, T2, T3, T4, T5> extends Task<Tuple5<T1, T2, T3, 
    *  Task{@code <String>} userName = id.flatMap("fetch", u {@code ->} fetch(u))
    *      .withSideEffect("update memcache", u {@code ->} updateMemcache(u));
    * </pre></blockquote>
-   * <img src="doc-files/withSideEffect-1.svg" type="image/svg+xml" height="120px"/>
+   * <img src="doc-files/withSideEffect-1.png" type="image/svg+xml" height="120px"/>
    *
    * @param desc description of a side effect, it will show up in a trace
    * @param func function to be applied on result of successful completion of this task

--- a/src/com/linkedin/parseq/Tuple6Task.java
+++ b/src/com/linkedin/parseq/Tuple6Task.java
@@ -27,7 +27,7 @@ public interface Tuple6Task<T1, T2, T3, T4, T5, T6> extends Task<Tuple6<T1, T2, 
    * // this task will complete with value 11
    * Task{@code <Integer>} length = hello.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task is completed with an exception then the new task will also complete
    * with that exception.
@@ -39,7 +39,7 @@ public interface Tuple6Task<T1, T2, T3, T4, T5, T6> extends Task<Tuple6<T1, T2, 
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <Integer>} length = failing.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
@@ -69,7 +69,7 @@ public interface Tuple6Task<T1, T2, T3, T4, T5, T6> extends Task<Tuple6<T1, T2, 
    *  // assuming fetch(u) fetches contents given by a URI
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    *
    * If this task is completed with an exception then the new task will also contain
@@ -80,7 +80,7 @@ public interface Tuple6Task<T1, T2, T3, T4, T5, T6> extends Task<Tuple6<T1, T2, 
    *  // this task will fail with java.lang.IllegalArgumentException
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-2.png" type="image/svg+xml" height="90px"/>
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
    * @param f function to be applied to successful result of this task which returns new task
@@ -111,7 +111,7 @@ public interface Tuple6Task<T1, T2, T3, T4, T5, T6> extends Task<Tuple6<T1, T2, 
    *  // this task will print "Hello World"
    *  Task{@code <String>} sayHello = hello.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task fails then consumer will not be called and failure
    * will be propagated to task returned by this method.
@@ -123,7 +123,7 @@ public interface Tuple6Task<T1, T2, T3, T4, T5, T6> extends Task<Tuple6<T1, T2, 
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <String>} sayHello = failing.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param desc description of a consumer, it will show up in a trace
    * @param consumer consumer of a value returned by this task
@@ -227,7 +227,7 @@ public interface Tuple6Task<T1, T2, T3, T4, T5, T6> extends Task<Tuple6<T1, T2, 
    *  Task{@code <String>} userName = id.flatMap("fetch", u {@code ->} fetch(u))
    *      .withSideEffect("update memcache", u {@code ->} updateMemcache(u));
    * </pre></blockquote>
-   * <img src="doc-files/withSideEffect-1.svg" type="image/svg+xml" height="120px"/>
+   * <img src="doc-files/withSideEffect-1.png" type="image/svg+xml" height="120px"/>
    *
    * @param desc description of a side effect, it will show up in a trace
    * @param func function to be applied on result of successful completion of this task

--- a/src/com/linkedin/parseq/Tuple7Task.java
+++ b/src/com/linkedin/parseq/Tuple7Task.java
@@ -27,7 +27,7 @@ public interface Tuple7Task<T1, T2, T3, T4, T5, T6, T7> extends Task<Tuple7<T1, 
    * // this task will complete with value 11
    * Task{@code <Integer>} length = hello.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task is completed with an exception then the new task will also complete
    * with that exception.
@@ -39,7 +39,7 @@ public interface Tuple7Task<T1, T2, T3, T4, T5, T6, T7> extends Task<Tuple7<T1, 
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <Integer>} length = failing.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
@@ -69,7 +69,7 @@ public interface Tuple7Task<T1, T2, T3, T4, T5, T6, T7> extends Task<Tuple7<T1, 
    *  // assuming fetch(u) fetches contents given by a URI
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    *
    * If this task is completed with an exception then the new task will also contain
@@ -80,7 +80,7 @@ public interface Tuple7Task<T1, T2, T3, T4, T5, T6, T7> extends Task<Tuple7<T1, 
    *  // this task will fail with java.lang.IllegalArgumentException
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-2.png" type="image/svg+xml" height="90px"/>
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
    * @param f function to be applied to successful result of this task which returns new task
@@ -111,7 +111,7 @@ public interface Tuple7Task<T1, T2, T3, T4, T5, T6, T7> extends Task<Tuple7<T1, 
    *  // this task will print "Hello World"
    *  Task{@code <String>} sayHello = hello.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task fails then consumer will not be called and failure
    * will be propagated to task returned by this method.
@@ -123,7 +123,7 @@ public interface Tuple7Task<T1, T2, T3, T4, T5, T6, T7> extends Task<Tuple7<T1, 
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <String>} sayHello = failing.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param desc description of a consumer, it will show up in a trace
    * @param consumer consumer of a value returned by this task
@@ -227,7 +227,7 @@ public interface Tuple7Task<T1, T2, T3, T4, T5, T6, T7> extends Task<Tuple7<T1, 
    *  Task{@code <String>} userName = id.flatMap("fetch", u {@code ->} fetch(u))
    *      .withSideEffect("update memcache", u {@code ->} updateMemcache(u));
    * </pre></blockquote>
-   * <img src="doc-files/withSideEffect-1.svg" type="image/svg+xml" height="120px"/>
+   * <img src="doc-files/withSideEffect-1.png" type="image/svg+xml" height="120px"/>
    *
    * @param desc description of a side effect, it will show up in a trace
    * @param func function to be applied on result of successful completion of this task

--- a/src/com/linkedin/parseq/Tuple8Task.java
+++ b/src/com/linkedin/parseq/Tuple8Task.java
@@ -27,7 +27,7 @@ public interface Tuple8Task<T1, T2, T3, T4, T5, T6, T7, T8> extends Task<Tuple8<
    * // this task will complete with value 11
    * Task{@code <Integer>} length = hello.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task is completed with an exception then the new task will also complete
    * with that exception.
@@ -39,7 +39,7 @@ public interface Tuple8Task<T1, T2, T3, T4, T5, T6, T7, T8> extends Task<Tuple8<
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <Integer>} length = failing.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
@@ -69,7 +69,7 @@ public interface Tuple8Task<T1, T2, T3, T4, T5, T6, T7, T8> extends Task<Tuple8<
    *  // assuming fetch(u) fetches contents given by a URI
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    *
    * If this task is completed with an exception then the new task will also contain
@@ -80,7 +80,7 @@ public interface Tuple8Task<T1, T2, T3, T4, T5, T6, T7, T8> extends Task<Tuple8<
    *  // this task will fail with java.lang.IllegalArgumentException
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-2.png" type="image/svg+xml" height="90px"/>
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
    * @param f function to be applied to successful result of this task which returns new task
@@ -111,7 +111,7 @@ public interface Tuple8Task<T1, T2, T3, T4, T5, T6, T7, T8> extends Task<Tuple8<
    *  // this task will print "Hello World"
    *  Task{@code <String>} sayHello = hello.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task fails then consumer will not be called and failure
    * will be propagated to task returned by this method.
@@ -123,7 +123,7 @@ public interface Tuple8Task<T1, T2, T3, T4, T5, T6, T7, T8> extends Task<Tuple8<
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <String>} sayHello = failing.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param desc description of a consumer, it will show up in a trace
    * @param consumer consumer of a value returned by this task
@@ -227,7 +227,7 @@ public interface Tuple8Task<T1, T2, T3, T4, T5, T6, T7, T8> extends Task<Tuple8<
    *  Task{@code <String>} userName = id.flatMap("fetch", u {@code ->} fetch(u))
    *      .withSideEffect("update memcache", u {@code ->} updateMemcache(u));
    * </pre></blockquote>
-   * <img src="doc-files/withSideEffect-1.svg" type="image/svg+xml" height="120px"/>
+   * <img src="doc-files/withSideEffect-1.png" type="image/svg+xml" height="120px"/>
    *
    * @param desc description of a side effect, it will show up in a trace
    * @param func function to be applied on result of successful completion of this task

--- a/src/com/linkedin/parseq/Tuple9Task.java
+++ b/src/com/linkedin/parseq/Tuple9Task.java
@@ -27,7 +27,7 @@ public interface Tuple9Task<T1, T2, T3, T4, T5, T6, T7, T8, T9> extends Task<Tup
    * // this task will complete with value 11
    * Task{@code <Integer>} length = hello.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task is completed with an exception then the new task will also complete
    * with that exception.
@@ -39,7 +39,7 @@ public interface Tuple9Task<T1, T2, T3, T4, T5, T6, T7, T8, T9> extends Task<Tup
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <Integer>} length = failing.map("length", s {@code ->} s.length());
    * </pre></blockquote>
-   * <img src="doc-files/map-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/map-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
@@ -69,7 +69,7 @@ public interface Tuple9Task<T1, T2, T3, T4, T5, T6, T7, T8, T9> extends Task<Tup
    *  // assuming fetch(u) fetches contents given by a URI
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    *
    * If this task is completed with an exception then the new task will also contain
@@ -80,7 +80,7 @@ public interface Tuple9Task<T1, T2, T3, T4, T5, T6, T7, T8, T9> extends Task<Tup
    *  // this task will fail with java.lang.IllegalArgumentException
    *  Task{@code <String>} homepage = url.flatMap("fetch", u {@code ->} fetch(u));
    * </pre></blockquote>
-   * <img src="doc-files/flatMap-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/flatMap-2.png" type="image/svg+xml" height="90px"/>
    * @param <R> return type of function <code>func</code>
    * @param desc description of a mapping function, it will show up in a trace
    * @param f function to be applied to successful result of this task which returns new task
@@ -111,7 +111,7 @@ public interface Tuple9Task<T1, T2, T3, T4, T5, T6, T7, T8, T9> extends Task<Tup
    *  // this task will print "Hello World"
    *  Task{@code <String>} sayHello = hello.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-1.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-1.png" type="image/svg+xml" height="90px"/>
    * <p>
    * If this task fails then consumer will not be called and failure
    * will be propagated to task returned by this method.
@@ -123,7 +123,7 @@ public interface Tuple9Task<T1, T2, T3, T4, T5, T6, T7, T8, T9> extends Task<Tup
    *  // this task will fail with java.lang.StringIndexOutOfBoundsException
    *  Task{@code <String>} sayHello = failing.andThen("say", System.out::println);
    * </pre></blockquote>
-   * <img src="doc-files/andThen-2.svg" type="image/svg+xml" height="90px"/>
+   * <img src="doc-files/andThen-2.png" type="image/svg+xml" height="90px"/>
    *
    * @param desc description of a consumer, it will show up in a trace
    * @param consumer consumer of a value returned by this task
@@ -227,7 +227,7 @@ public interface Tuple9Task<T1, T2, T3, T4, T5, T6, T7, T8, T9> extends Task<Tup
    *  Task{@code <String>} userName = id.flatMap("fetch", u {@code ->} fetch(u))
    *      .withSideEffect("update memcache", u {@code ->} updateMemcache(u));
    * </pre></blockquote>
-   * <img src="doc-files/withSideEffect-1.svg" type="image/svg+xml" height="120px"/>
+   * <img src="doc-files/withSideEffect-1.png" type="image/svg+xml" height="120px"/>
    *
    * @param desc description of a side effect, it will show up in a trace
    * @param func function to be applied on result of successful completion of this task


### PR DESCRIPTION
Tuple*Task.java javadoc's image points to the image files which has a wrong file extension, which lead to the result that the .html file can not find the image files.

Update:
Since all the Tuple*Task.java source code are generated by freemarker template, we changed the template to set the right image extension, and then regenerate the source code.