### PR TITLE
Update README file and fix vulnerable dependencies in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ v3.0.1
 
 v3.0.0
 ------
-
+* Update README file and fix vulnerable dependencies in package.json
 * Migrate to Gradle build automation
 
 v2.6.36

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Some of the key benefits of ParSeq include:
 * [Code reuse via task composition](https://github.com/linkedin/parseq/wiki/User%27s-Guide#composiing-tasks)
 * [Simple error propagation and recovery](https://github.com/linkedin/parseq/wiki/User%27s-Guide#handling-errors)
 * [Execution tracing and visualization](https://github.com/linkedin/parseq/wiki/Tracing)
-* [Batching of asynchronous operations](https://github.com/linkedin/parseq/tree/master/contrib/parseq-batching)
+* [Batching of asynchronous operations](https://github.com/linkedin/parseq/tree/master/subprojects/parseq-batching)
 * [Tasks with retry policy](https://github.com/linkedin/parseq/wiki/User%27s-Guide#retrying)
 
 [Our Wiki](https://github.com/linkedin/parseq/wiki) includes an introductory example, a User's Guide, javadoc, and more.
@@ -20,9 +20,9 @@ See [CHANGELOG](https://github.com/linkedin/parseq/blob/master/CHANGELOG.md) for
 
 In this example we show how to fetch several pages in parallel and how to combine them once they've all been retrieved.
 
-You can find source code here: [IntroductoryExample](https://github.com/linkedin/parseq/tree/master/contrib/parseq-examples/src/main/java/com/linkedin/parseq/example/introduction/IntroductoryExample.java).
+You can find source code here: [IntroductoryExample](https://github.com/linkedin/parseq/tree/master/subprojects/parseq-examples/src/main/java/com/linkedin/parseq/example/introduction/IntroductoryExample.java).
 
-First we can retrieve a single page using an [asynchronous HTTP client](https://github.com/linkedin/parseq/tree/master/contrib/parseq-http-client) as follows:
+First we can retrieve a single page using an [asynchronous HTTP client](https://github.com/linkedin/parseq/tree/master/subprojects/parseq-http-client) as follows:
 
 ```java
     final Task<Response> google = HttpClient.get("http://www.google.com").task();
@@ -98,7 +98,7 @@ Graphviz diagram best describes relationships between tasks:
 
 For more in-depth description of ParSeq please visit [User's Guide](https://github.com/linkedin/parseq/wiki/User's-Guide).
 
-For many more examples, please see the [parseq-examples](https://github.com/linkedin/parseq/tree/master/contrib/parseq-examples) contrib project in the source code.
+For many more examples, please see the [parseq-examples](https://github.com/linkedin/parseq/tree/master/subprojects/parseq-examples) contrib project in the source code.
 
 ## Build Status
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,12 @@ allprojects { // for all projects including the root project
   }
 }
 
+idea {
+  project {
+    jdkName = '1.8.0_121'
+    languageLevel = '1.8'
+  }
+}
 
 subprojects {
   apply plugin: 'java'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.6.36
+version=3.0.0
 sonatypeUsername=please_set_in_home_dir_if_uploading_to_maven_central
 sonatypePassword=please_set_in_home_dir_if_uploading_to_maven_central
 

--- a/subprojects/parseq-batching/README.md
+++ b/subprojects/parseq-batching/README.md
@@ -145,7 +145,7 @@ Finally we need to define main API for our ```ParSeqPersonClient```:
 ```
 ```batchable()``` method is declared by a ```BatchingStrategy``` and returns a task that cooperates with a batching strategy to performa a batchable operation.
 
-Source code for above example can be found [here](https://github.com/linkedin/parseq/blob/master/contrib/parseq-examples/src/main/java/com/linkedin/parseq/example/domain/ParSeqPersonClient.java).
+Source code for above example can be found [here](https://github.com/linkedin/parseq/blob/master/subprojects/parseq-examples/src/main/java/com/linkedin/parseq/example/domain/ParSeqPersonClient.java).
 
 Task-based BatchingStrategy
 ===========================

--- a/subprojects/parseq-lambda-names/build.gradle
+++ b/subprojects/parseq-lambda-names/build.gradle
@@ -65,3 +65,5 @@ uploadArchives {
     }
   }
 }
+
+compileJava.options.compilerArgs += '-Xlint:-unchecked'

--- a/subprojects/parseq-restli-client/README.md
+++ b/subprojects/parseq-restli-client/README.md
@@ -8,13 +8,13 @@ This project provides implementation of ParSeq rest.li client. It provides two f
 Batching
 ========
 
-ParSeq rest.li client is using ParSeq [Batching](https://github.com/linkedin/parseq/tree/master/contrib/parseq-batching) feature to transparently aggregate individual requests into BATCH requests. Currently only GET and BATCH_GET operations are supported. Batching functionality can be selectively enabled for subset of requests made by ParSeq rest.li client.
+ParSeq rest.li client is using ParSeq [Batching](https://github.com/linkedin/parseq/tree/master/subprojects/parseq-batching) feature to transparently aggregate individual requests into BATCH requests. Currently only GET and BATCH_GET operations are supported. Batching functionality can be selectively enabled for subset of requests made by ParSeq rest.li client.
 
 Configuration
 =============
 ParSeq rest.li client implementation allows fine-grained configuration of the following properties:
  * timeoutMs (long) - timeout in milliseconds. Returned Task will complete with TimeoutException if response is not available within specified amount of time. TimeoutException contains information about what configuration has caused it.
- * batchingEnabled (boolean) - is batching enabled. Enables batching functionality for specified subset of requests. See [Batching](https://github.com/linkedin/parseq/tree/master/contrib/parseq-batching) for more information about this feature. Currently only GET and BATCH_GET operations are supported.
+ * batchingEnabled (boolean) - is batching enabled. Enables batching functionality for specified subset of requests. See [Batching](https://github.com/linkedin/parseq/tree/master/subprojects/parseq-batching) for more information about this feature. Currently only GET and BATCH_GET operations are supported.
  * maxBatchSize (int) - Max batch size. Maximum number of keys that will be aggregated together into one BATCH request. If there are more requests that can be batched then they will be grouped into number of BATCH requests, for example, if maxBatchSize is 100 and there are 256 GET requests, then they will be aggregated into 3 BATCH_GET requests containing respectively: 100, 100, 56 elements. However, maxBatchSize does not affect existing rest.li BATCH_GET requests, and it is only used to limit size of batch requests created as a result of aggregation. For example, if maxBatchSize is 100 and there are a BATCH_GET request with 120 elements and 120 GET requests, then they will be aggregated into 3 BATCH_GET requests containing respectively 120, 100, 20 elements. Note that the original 120-element BATCH_GET request will not be splitted into smaller batches.
 
 Each property is defined by a set of Key-Value pairs where Key has the following form:

--- a/subprojects/parseq-tracevis/package.json
+++ b/subprojects/parseq-tracevis/package.json
@@ -10,7 +10,7 @@
     "istanbul": "~0.1.44",
     "mocha": "1.2.x",
     "phantomjs": "~1.9.2-2",
-    "uglify-js": "1.2.3"
+    "uglify-js": "2.6.0"
   },
   "dependencies": {
     "d3": "3.3.5",

--- a/subprojects/parseq/build.gradle
+++ b/subprojects/parseq/build.gradle
@@ -29,6 +29,9 @@ configurations {
   testUtilCompile {
     description "test utility compile time dependencies"
   }
+  compile {
+    extendsFrom testUtilCompile
+  }
 }
 
 dependencies {
@@ -37,26 +40,40 @@ dependencies {
   compile group: "org.slf4j", name: "slf4j-api", version: "1.7.25"
   bootstrap group: "net.sourceforge.fmpp", name: "fmpp", version: "0.9.15"
 
-  testUtilCompile group: "org.testng", name: "testng", version: "6.9.9"
+  testCompile group: "org.testng", name: "testng", version: "6.9.9"
   testCompile group: "org.slf4j", name: "slf4j-log4j12", version: "1.7.25"
+}
+
+test {
+  useTestNG()
+}
+
+idea {
+  module {
+    testSourceDirs += file('src/test-utils/java')
+  }
 }
 
 sourceSets {
   testUtils {
-    compileClasspath += sourceSets.main.compileClasspath + sourceSets.main.runtimeClasspath + configurations.compile + configurations.testUtilCompile + sourceSets.main.output
-    runtimeClasspath += sourceSets.main.compileClasspath + output
+    compileClasspath += sourceSets.main.compileClasspath + configurations.compile + configurations.testCompile + sourceSets.main.output
     java {
       srcDirs = ['src/test-utils/java']
     }
   }
 
   test {
-    java {
-      srcDirs = ['test']
-      compileClasspath += testUtils.output + compileClasspath + configurations.testRuntime
-      runtimeClasspath += testUtils.output + compileClasspath + configurations.testRuntime
-    }
+      compileClasspath += sourceSets.testUtils.output
+      runtimeClasspath += sourceSets.testUtils.output
+      java {
+        srcDirs = ['src/test-utils/java']
+      }
   }
+}
+
+compileTestJava {
+  dependsOn compileTestUtilsJava
+  classpath += sourceSets.testUtils.output + configurations.testCompile
 }
 
 javadoc {


### PR DESCRIPTION
Since parseq is migrated to Gradle, some link path in Readme file need to be updated. 
Also, parseq-tracevis has vulnerable dependencies issue, so upgrade the packages.