### PR TITLE
Make ParSeq batch get requests with exactly the same key type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
-v3.0.3
+v3.0.4
 ------
 
 
+
+v3.0.3
+------
+
+* Make ParSeq batch get requests with exactly the same key type
 
 v3.0.2
 ------

--- a/subprojects/parseq-restli-client/src/main/java/com/linkedin/restli/client/GetRequestGroup.java
+++ b/subprojects/parseq-restli-client/src/main/java/com/linkedin/restli/client/GetRequestGroup.java
@@ -449,6 +449,13 @@ class GetRequestGroup implements RequestGroup {
         return false;
     } else if (!_requestOptions.equals(other._requestOptions))
       return false;
+    if (_resourceSpec == null){
+      if (other._resourceSpec != null) {
+        return false;
+      }
+    } else if (_resourceSpec.getKeyClass() != other._resourceSpec.getKeyClass()) {
+      return false;
+    }
     return true;
   }
 

--- a/subprojects/parseq-restli-client/src/main/java/com/linkedin/restli/client/RestRequestBatchKey.java
+++ b/subprojects/parseq-restli-client/src/main/java/com/linkedin/restli/client/RestRequestBatchKey.java
@@ -31,13 +31,13 @@ import com.linkedin.restli.client.config.RequestConfig;
 class RestRequestBatchKey {
   private final Request<?> _request;
   private final RequestContext _requestContext;
-  private final RequestConfig _bathcingConfig;
+  private final RequestConfig _batchingConfig;
   private Set<String> _extractedIds;
 
-  public RestRequestBatchKey(Request<Object> request, RequestContext requestContext, RequestConfig bathcingConfig) {
+  public RestRequestBatchKey(Request<Object> request, RequestContext requestContext, RequestConfig batchingConfig) {
     _request = request;
     _requestContext = requestContext;
-    _bathcingConfig = bathcingConfig;
+    _batchingConfig = batchingConfig;
   }
 
   public Request<?> getRequest() {
@@ -49,7 +49,7 @@ class RestRequestBatchKey {
   }
 
   public RequestConfig getRequestConfig() {
-    return _bathcingConfig;
+    return _batchingConfig;
   }
 
   @Override

--- a/subprojects/parseq-restli-client/src/test/java/com/linkedin/restli/client/ParSeqRestClientIntegrationTest.java
+++ b/subprojects/parseq-restli-client/src/test/java/com/linkedin/restli/client/ParSeqRestClientIntegrationTest.java
@@ -17,10 +17,7 @@
 package com.linkedin.restli.client;
 
 import com.linkedin.data.schema.PathSpec;
-import com.linkedin.data.template.DynamicRecordMetadata;
 import com.linkedin.r2.filter.FilterChains;
-import com.linkedin.restli.client.base.GetRequestBuilderBase;
-import com.linkedin.restli.common.CompoundKey;
 import com.linkedin.restli.common.ResourceMethod;
 import com.linkedin.restli.common.ResourceSpec;
 import com.linkedin.restli.common.ResourceSpecImpl;

--- a/subprojects/parseq-restli-client/src/test/java/com/linkedin/restli/client/ParSeqRestClientIntegrationTest.java
+++ b/subprojects/parseq-restli-client/src/test/java/com/linkedin/restli/client/ParSeqRestClientIntegrationTest.java
@@ -17,10 +17,17 @@
 package com.linkedin.restli.client;
 
 import com.linkedin.data.schema.PathSpec;
+import com.linkedin.data.template.DynamicRecordMetadata;
 import com.linkedin.r2.filter.FilterChains;
+import com.linkedin.restli.client.base.GetRequestBuilderBase;
+import com.linkedin.restli.common.CompoundKey;
+import com.linkedin.restli.common.ResourceMethod;
+import com.linkedin.restli.common.ResourceSpec;
+import com.linkedin.restli.common.ResourceSpecImpl;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -160,6 +167,13 @@ public abstract class ParSeqRestClientIntegrationTest extends BaseEngineTest {
     return _parseqClient.createTask(new GreetingsBuilders().get().id(id).build());
   }
 
+  // This method is for the "testBatchingGetRequestsWithDiffKeyType" test to create a request with String Key type.
+  protected Task<Response<Greeting>> greetingGetWithStringKey(String id) {
+    String _baseUriTemplate = "greetings";
+    ResourceSpec _resourceSpec = new ResourceSpecImpl(EnumSet.allOf(ResourceMethod.class), Collections.emptyMap(), Collections.emptyMap(), String.class, null, null, Greeting.class, Collections.emptyMap());
+    return _parseqClient.createTask(new GetRequestBuilder(_baseUriTemplate, Greeting.class, _resourceSpec, RestliRequestOptions.DEFAULT_OPTIONS).id(id).build());
+  }
+
   protected Task<Response<Greeting>> greetingGetWithProjection(Long id, PathSpec... fields) {
     return _parseqClient.createTask(new GreetingsBuilders().get().id(id).fields(fields).build());
   }
@@ -208,5 +222,4 @@ public abstract class ParSeqRestClientIntegrationTest extends BaseEngineTest {
     Map<String, Object> map = config.computeIfAbsent(property, k -> new HashMap<>());
     map.put(key, value);
   }
-
 }

--- a/subprojects/parseq-restli-client/src/test/java/com/linkedin/restli/client/TestParSeqRestClient.java
+++ b/subprojects/parseq-restli-client/src/test/java/com/linkedin/restli/client/TestParSeqRestClient.java
@@ -157,6 +157,22 @@ public class TestParSeqRestClient extends ParSeqRestClientIntegrationTest {
   }
 
   @Test
+  public void testBatchingGetRequestsWithDiffKeyType() {
+    try {
+      setInboundRequestContext(new InboundRequestContextBuilder()
+          .setName("withBatching")
+          .build());
+      Task<?> t1  = greetingGet(1L);
+      Task<?> t2 = greetingGetWithStringKey("1");
+      Task<?> task = Task.par(t1, t2);
+      runAndWait(getTestClassName() + ".testBatchingGetRequestsWithDiffKeyType", task);
+      assertFalse(hasTask("greetings batch_get(reqs: 2, ids: 2)", task.getTrace()));
+    } finally {
+      clearInboundRequestContext();
+    }
+  }
+
+  @Test
   public void testBatchingGetRequestsMaxExceeded() {
     try {
       setInboundRequestContext(new InboundRequestContextBuilder()


### PR DESCRIPTION
Currently, ParSeq batch the get requests even the requests have different key type. This would get a 404 status when unbatch the response, since ParSeq always try to use the first request (use its type information) to send the batch request and unbatch response, this would cause this failure.

Update:

- This fix is to force the ParSeq only batch the requests with exactly the same key type.
- Fix the typo in RestRequestBatchKey class.
