### PR TITLE
Fix parseq-tracevis.jar configuration bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
+v3.0.6
+------
+
+
 v3.0.5
 ------
+
+* Fix parseq-tracevis.jar configuration bug
 
 v3.0.4
 ------

--- a/build.gradle
+++ b/build.gradle
@@ -24,56 +24,59 @@ idea {
 }
 
 subprojects {
-  apply plugin: 'java'
-  sourceCompatibility = 1.8
-  targetCompatibility = 1.8
   archivesBaseName = project.name
 
-  test {
-    useTestNG()
-  }
+  if (!it.name.equals("parseq-tracevis")) {
+    apply plugin: 'java'
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 
-  if (it.name.startsWith('parseq-') && !it.name.equals("parseq-lambda-names") && !it.name.equals("parseq-tracevis")) { // all contrib modules
-    dependencies {
-      compile project(":parseq")
+    test {
+      useTestNG()
     }
-  }
 
-  // package jar
-  task packageJavadoc(type: Jar, dependsOn: 'javadoc') {
-    from javadoc.destinationDir
-    classifier = 'javadoc'
-  }
-
-  task packageSources(type: Jar, dependsOn: 'classes') {
-    from sourceSets.main.allSource
-    classifier = 'sources'
-  }
-
-  // configure MANIFEST
-  jar {
-    manifest {
-      attributes("Created-By": "Gradle",
-          "Version": version,
-          "Built-By": sonatypeUsername,
-          "Build-JDK": JavaVersion.current())
+    if (it.name.startsWith('parseq-') && !it.name.equals("parseq-lambda-names")) { // all contrib modules
+      dependencies {
+        compile project(":parseq")
+      }
     }
-  }
+
+    // package jar
+    task packageJavadoc(type: Jar, dependsOn: 'javadoc') {
+      from javadoc.destinationDir
+      classifier = 'javadoc'
+    }
+
+    task packageSources(type: Jar, dependsOn: 'classes') {
+      from sourceSets.main.allSource
+      classifier = 'sources'
+    }
+
+    // configure MANIFEST
+    jar {
+      manifest {
+        attributes("Created-By": "Gradle",
+            "Version": version,
+            "Built-By": sonatypeUsername,
+            "Build-JDK": JavaVersion.current())
+      }
+    }
 
 
-  javadoc {
-    options.use = true
-    options.author = true
-    options.bottom = "Copyright &#169; 2018. All rights reserved."
-    options.classpath += file("${project.projectDir.absolutePath}/src/main/java")
-    options.links("https://docs.oracle.com/javase/8/docs/api/")
-    options.addStringOption("charset", "UTF-8")
-  }
+    javadoc {
+      options.use = true
+      options.author = true
+      options.bottom = "Copyright &#169; 2018. All rights reserved."
+      options.classpath += file("${project.projectDir.absolutePath}/src/main/java")
+      options.links("https://docs.oracle.com/javase/8/docs/api/")
+      options.addStringOption("charset", "UTF-8")
+    }
 
-  if (JavaVersion.current().isJava8Compatible()) {
-    allprojects {
-      tasks.withType(Javadoc) {
-        options.addStringOption('Xdoclint:none', '-quiet')
+    if (JavaVersion.current().isJava8Compatible()) {
+      allprojects {
+        tasks.withType(Javadoc) {
+          options.addStringOption('Xdoclint:none', '-quiet')
+        }
       }
     }
   }


### PR DESCRIPTION
Currently, the build.gradle file in the root project apply the "java plugin" to all sub modules, for the parseq-tracevis module(not a java project), it would generate the "publication" in the ivy.xml for the default parseq-tracevis.jar file automatically, which would lead to a wrong dependency import for other project.

Fix:
Exclude the "parseq-tracevis" module from "java plugin"