### PR TITLE
Add support for static withSideEffect

### DIFF
--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/Task.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/Task.java
@@ -338,9 +338,9 @@ public interface Task<T> extends Promise<T>, Cancellable {
    * @param func function to be applied to get side effect task
    * @return a new Task that will run the side effect Task
    */
-  static <T> Task<T> withSideEffect(final String desc, final Callable<Task<T>> func) {
+  static <T> Task<Void> withSideEffect(final String desc, final Callable<Task<T>> func) {
     ArgumentUtil.requireNotNull(func, "function");
-    final Task<T> sideEffectWrapper = async(desc, ctx -> {
+    final Task<Void> sideEffectWrapper = async(desc, ctx -> {
       Task<?> sideEffect = func.call();
       ctx.runSideEffect(sideEffect);
 
@@ -355,7 +355,7 @@ public interface Task<T> extends Promise<T>, Cancellable {
    * Equivalent to {@code Task.withSideEffect("withSideEffect", func)}.
    * @see Task#withSideEffect(String, Callable)
    */
-  static <T> Task<T> withSideEffect(final Callable<Task<T>> func) {
+  static <T> Task<Void> withSideEffect(final Callable<Task<T>> func) {
     return Task.withSideEffect("withSideEffect", func);
   }
 

--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/Task.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/Task.java
@@ -316,6 +316,50 @@ public interface Task<T> extends Promise<T>, Cancellable {
   }
 
   /**
+   * Creates a new Task that will run another task as a side effect. The side effect task will return immediately with
+   * an empty {@link Task} and the enclosed Task will execute asynchronously. The properties of static side effect task
+   * are:
+   * <ul>
+   *   <li>
+   *     The side effect will complete successfully even though the underlying Task fails
+   *   </li>
+   *   <li>
+   *     The side effect will always complete with a {@code null} value
+   *   </li>
+   * </ul>
+   *
+   * Side effect in static context is useful in situations where control needs to be returned to caller immediately
+   * and the Task can execute in background. In this case, caller should not be concerned with success or failure of
+   * background Task.
+   *
+   * Static side effect can be thought of as a side effect being attached to an empty Task. like:
+   * {@code Task.value(null).withSideEffect(() -> Task.value("hello world")); }
+   * @param desc description of a side effect, it will show up in a trace
+   * @param func function to be applied to get side effect task
+   * @return a new Task that will run the side effect Task
+   */
+  static <T> Task<T> withSideEffect(final String desc, final Callable<Task<T>> func) {
+    ArgumentUtil.requireNotNull(func, "function");
+    final Task<T> sideEffectWrapper = async(desc, ctx -> {
+      Task<?> sideEffect = func.call();
+      ctx.runSideEffect(sideEffect);
+
+      return Promises.value(null);
+    });
+
+    sideEffectWrapper.getShallowTraceBuilder().setTaskType(TaskType.WITH_SIDE_EFFECT.getName());
+    return sideEffectWrapper;
+  }
+
+  /**
+   * Equivalent to {@code Task.withSideEffect("sideEffect", func)}.
+   * @see Task#withSideEffect(String, Callable)
+   */
+  static <T> Task<T> withSideEffect(final Callable<Task<T>> func) {
+    return Task.withSideEffect("sideEffect", func);
+  }
+
+  /**
    * Creates a new task that can be safely shared within a plan or between multiple
    * plans. Cancellation of returned task will not cause cancellation of the original task.
    * <p>

--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/Task.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/Task.java
@@ -352,7 +352,7 @@ public interface Task<T> extends Promise<T>, Cancellable {
   }
 
   /**
-   * Equivalent to {@code Task.withSideEffect("sideEffect", func)}.
+   * Equivalent to {@code Task.withSideEffect("withSideEffect", func)}.
    * @see Task#withSideEffect(String, Callable)
    */
   static <T> Task<T> withSideEffect(final Callable<Task<T>> func) {

--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/Task.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/Task.java
@@ -356,7 +356,7 @@ public interface Task<T> extends Promise<T>, Cancellable {
    * @see Task#withSideEffect(String, Callable)
    */
   static <T> Task<T> withSideEffect(final Callable<Task<T>> func) {
-    return Task.withSideEffect("sideEffect", func);
+    return Task.withSideEffect("withSideEffect", func);
   }
 
   /**

--- a/subprojects/parseq/src/test/java/com/linkedin/parseq/AbstractTaskTest.java
+++ b/subprojects/parseq/src/test/java/com/linkedin/parseq/AbstractTaskTest.java
@@ -300,7 +300,7 @@ public abstract class AbstractTaskTest extends BaseEngineTest {
   @Test
   public void testStaticWithSideEffectFullCompletion() throws Exception {
     Task<String> slowSideEffect = delayedValue("slow", 50, TimeUnit.MILLISECONDS);
-    Task<String> sideEffect = Task.withSideEffect(() -> slowSideEffect);
+    Task<Void> sideEffect = Task.withSideEffect(() -> slowSideEffect);
 
     run(sideEffect);
     assertFalse(sideEffect.isDone());
@@ -312,7 +312,7 @@ public abstract class AbstractTaskTest extends BaseEngineTest {
   @Test
   public void testStaticSideEffectFailureIsIgnored() throws Exception {
     Task<String> failureTask = getFailureTask();
-    Task<String> sideEffect = Task.withSideEffect(() -> failureTask);
+    Task<Void> sideEffect = Task.withSideEffect(() -> failureTask);
 
     runAndWait(sideEffect);
     assertFalse(sideEffect.isFailed());


### PR DESCRIPTION
For #132 and #133 

Added support for  `static` `Task.withSideeffect` to replace using Parseq API for cases where other usages like `Task.value(null).withSideEffect(...)` were being used.