### PR TITLE
Add support for Task.withDelay (#210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 v3.0.7
 ------
-
+* Add support for Task.withDelay to expose an easy-to-use API for delaying task execution. See issue #210 on Github.
 
 v3.0.6
 ------

--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/Task.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/Task.java
@@ -902,7 +902,7 @@ public interface Task<T> extends Promise<T>, Cancellable {
   }
 
   /**
-   * Creates a new task whose execution is delayed.
+   * Creates a new task that delays the execution of this task by the given duration.
    * This task will complete with the exact same result as the delayed task, whether it is
    * a success or failure.
    * <blockquote><pre>
@@ -910,8 +910,11 @@ public interface Task<T> extends Promise<T>, Cancellable {
    *     .withDelay(1, TimeUnit.SECONDS);
    * </pre></blockquote>
    *
-   * @param desc description of the delayed task. There is no need to put the delay value here because it will be
-   * automatically included, prepended to the description, if it is provided (e.g. withDelay 1s send request to Google).
+   * @param desc description of the delayed task. There is no need to put delay value here because it will be automatically
+   * included. Full description of a delay will be: {@code "withDelay " + time + " " + TimeUnitHelper.toString(unit) +
+   * (desc != null ? " " + desc : "")}. It is a good idea to put information that will help understand why the delay
+   * was specified e.g. if delay was specified by a configuration, the configuration parameter name would be useful
+   * information.
    * @param time the time to wait before executing this task
    * @param unit the unit for the time
    * @return the new task with a delay

--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/Task.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/Task.java
@@ -910,11 +910,8 @@ public interface Task<T> extends Promise<T>, Cancellable {
    *     .withDelay(1, TimeUnit.SECONDS);
    * </pre></blockquote>
    *
-   * @param desc description of the delayed task. There is no need to put delay value here because it will be automatically
-   *    * included. Full description of a delay will be: {@code "withDelay " + time + " " + TimeUnitHelper.toString(unit) +
-   *    * (desc != null ? " " + desc : "")}. It is a good idea to put information that will help understand why the delay
-   *    * was specified e.g. if delay was specified by a configuration, the configuration parameter name would be a useful
-   *    * information
+   * @param desc description of the delayed task. There is no need to put the delay value here because it will be
+   * automatically included, prepended to the description, if it is provided (e.g. withDelay 1s send request to Google).
    * @param time the time to wait before executing this task
    * @param unit the unit for the time
    * @return the new task with a delay

--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/TaskType.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/TaskType.java
@@ -15,7 +15,8 @@ public enum TaskType {
   TIMEOUT ("timeout"),
   WITH_TIMEOUT ("withTimeout"),
   RECOVER ("recover"),
-  WITH_RECOVER ("withRecover");
+  WITH_RECOVER ("withRecover"),
+  WITH_DELAY ("withDelay");
 
   private final String _name;
 

--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/internal/ArgumentUtil.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/internal/ArgumentUtil.java
@@ -38,7 +38,13 @@ public class ArgumentUtil {
 
   public static void requirePositive(final int n, final String name) {
     if (n <= 0) {
-      throw new IllegalArgumentException(name + " must be a positive integer numebr, but is: " + n);
+      throw new IllegalArgumentException(name + " must be a positive integer number, but is: " + n);
+    }
+  }
+
+  public static void requirePositive(final long n, final String name) {
+    if (n <= 0) {
+      throw new IllegalArgumentException(name + " must be a positive long number, but is: " + n);
     }
   }
 }

--- a/subprojects/parseq/src/test/java/com/linkedin/parseq/TestTaskType.java
+++ b/subprojects/parseq/src/test/java/com/linkedin/parseq/TestTaskType.java
@@ -86,6 +86,14 @@ public class TestTaskType extends TestTask {
     assertEquals(task.getShallowTrace().getTaskType(), TaskType.WITH_RECOVER.getName());
   }
 
+  @Test
+  public void testWithDelayTaskType() {
+    Task<?> taskWithDelay = Task.value("test").withDelay(100, TimeUnit.MILLISECONDS);
+
+    runAndWait("taskWithDelayTaskType", taskWithDelay);
+    assertEquals(taskWithDelay.getShallowTrace().getTaskType(), TaskType.WITH_DELAY.getName());
+  }
+
   private boolean doesTaskTypeExistInTrace(Trace trace, String taskType) {
     return trace.getTraceMap().values().stream().anyMatch(shallowTrace -> taskType.equals(shallowTrace.getTaskType()));
   }


### PR DESCRIPTION
Add support for Task.withDelay: #210 

This allows developers to delay a Task after a specified duration.

Also includes a new ArgumentUtil.requirePositive validation function that operates on long types.