### PR TITLE
Support HTTPS in parseq-tracevis-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
-v3.0.6
+v3.0.8
 ------
 
+
+v3.0.7
+------
+* Support HTTPS in parseq-tracevis-server
+* Add support for Task.withDelay to expose an easy-to-use API for delaying task execution. See issue #210 on Github.
+
+v3.0.6
+------
+* In ParSeqRestClient align createTaskWithD2Timeout and createTaskWithTimeout to always run the timeout task with the same approach.
+  We want to guarantee the exact same behavior in the two cases since the restli stack might not timeout properly
 
 v3.0.5
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,16 @@ v3.0.8
 
 v3.0.7
 ------
+
 * Support HTTPS in parseq-tracevis-server
 * Add support for Task.withDelay to expose an easy-to-use API for delaying task execution. See issue #210 on Github.
 
 v3.0.6
 ------
+
 * In ParSeqRestClient align createTaskWithD2Timeout and createTaskWithTimeout to always run the timeout task with the same approach.
   We want to guarantee the exact same behavior in the two cases since the restli stack might not timeout properly
+* Add support for static withSideEffect
 
 v3.0.5
 ------

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=3.0.6
+version=3.0.7
 sonatypeUsername=please_set_in_home_dir_if_uploading_to_maven_central
 sonatypePassword=please_set_in_home_dir_if_uploading_to_maven_central
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=3.0.5
+version=3.0.6
 sonatypeUsername=please_set_in_home_dir_if_uploading_to_maven_central
 sonatypePassword=please_set_in_home_dir_if_uploading_to_maven_central
 

--- a/subprojects/parseq-tracevis-server/README.md
+++ b/subprojects/parseq-tracevis-server/README.md
@@ -31,6 +31,11 @@ Run server passing path to `dot` as an argument e.g. `java -jar parseq-tracevis-
 You can optionally specify port number, by default it will run on port 8080.
 
 
+Configure Https Server
+======================================
+Follow [config.properties](https://github.com/linkedin/parseq/blob/master/subprojects/parseq-tracevis-server/config.properties) to set up SSL properties, then run server by passing this property file
+as an argument, eg. `java -jar parseq-tracevis-server-jar-with-dependencies.jar /usr/bin/dot <path to config.properties file>`
+
 Docker
 ======================================
 

--- a/subprojects/parseq-tracevis-server/config.properties
+++ b/subprojects/parseq-tracevis-server/config.properties
@@ -1,0 +1,6 @@
+httpPort = YourHttpPortNumber
+sslPort = YourHttpsPortNumber
+trustStorePassword = YourTrustStorePassword
+trustStorePath = YourTrustStorePath
+keyStorePassword = YourKeyStorePassword
+keyStorePath = YourKeyStorePath

--- a/subprojects/parseq-tracevis-server/src/main/java/com/linkedin/parseq/HealthCheckHandler.java
+++ b/subprojects/parseq-tracevis-server/src/main/java/com/linkedin/parseq/HealthCheckHandler.java
@@ -1,0 +1,26 @@
+package com.linkedin.parseq;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+
+
+/**
+ * This class is for health check to check whether the service is running well or not.
+ */
+public class HealthCheckHandler extends AbstractHandler {
+
+  @Override
+  public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
+      throws IOException, ServletException {
+    if (target.equals("/admin")) {
+      response.setContentType("text/html;charset=utf-8");
+      response.setStatus(HttpServletResponse.SC_OK);
+      baseRequest.setHandled(true);
+      response.getWriter().println("GOOD");
+    }
+  }
+}

--- a/subprojects/parseq-tracevis-server/src/main/java/com/linkedin/parseq/TracevisHttpsServer.java
+++ b/subprojects/parseq-tracevis-server/src/main/java/com/linkedin/parseq/TracevisHttpsServer.java
@@ -1,6 +1,7 @@
 package com.linkedin.parseq;
 
 import java.nio.file.Path;
+import java.util.Arrays;
 import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.server.Connector;
@@ -32,8 +33,7 @@ public class TracevisHttpsServer extends TracevisServer {
       String keyStorePath,
       String keyStorePassword,
       String trustStorePath,
-      String trustStorePassword)
-  {
+      String trustStorePassword) {
     super(dotLocation, port, baseLocation, heapsterLocation, cacheSize, timeoutMs);
     _sslPort = sslPort;
     _keyStorePath = keyStorePath;
@@ -43,8 +43,7 @@ public class TracevisHttpsServer extends TracevisServer {
   }
 
   @Override
-  protected Connector[] getConnectors(Server server)
-  {
+  protected Connector[] getConnectors(Server server) {
     SslContextFactory sslContextFactory = new SslContextFactory();
     sslContextFactory.setKeyStorePath(_keyStorePath);
     sslContextFactory.setKeyStorePassword(_keyStorePassword);
@@ -57,19 +56,13 @@ public class TracevisHttpsServer extends TracevisServer {
     config.addCustomizer(new SecureRequestCustomizer());
 
     ServerConnector sslConnector =
-        new ServerConnector(_server, new SslConnectionFactory(sslContextFactory, HttpVersion.HTTP_1_1.asString()), new HttpConnectionFactory(config));
+        new ServerConnector(server, new SslConnectionFactory(sslContextFactory, HttpVersion.HTTP_1_1.asString()), new HttpConnectionFactory(config));
     sslConnector.setPort(_sslPort);
 
 
     Connector[] httpConnectors = super.getConnectors(server);
-    Connector[] connectors = new Connector[httpConnectors.length + 1];
-
-    int i  = 0;
-    for (Connector c : httpConnectors)
-    {
-      connectors[i++] = c;
-    }
-    connectors[i++] = sslConnector;
+    Connector[] connectors = Arrays.copyOf(httpConnectors, httpConnectors.length + 1);
+    connectors[httpConnectors.length] = sslConnector;
 
     return connectors;
   }

--- a/subprojects/parseq-tracevis-server/src/main/java/com/linkedin/parseq/TracevisHttpsServer.java
+++ b/subprojects/parseq-tracevis-server/src/main/java/com/linkedin/parseq/TracevisHttpsServer.java
@@ -1,0 +1,76 @@
+package com.linkedin.parseq;
+
+import java.nio.file.Path;
+import org.eclipse.jetty.http.HttpScheme;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+
+
+/**
+ * This class is to set up SSL connector for supporting https.
+ *
+ * @author Jiaqi Guan
+ */
+public class TracevisHttpsServer extends TracevisServer {
+
+  private final int _sslPort;
+  private final String _keyStorePath;
+  private final String _keyStorePassword;
+  private final String _trustStorePath;
+  private final String _trustStorePassword;
+
+  public TracevisHttpsServer(final String dotLocation, final int port, final Path baseLocation, final Path heapsterLocation,
+      final int cacheSize, final long timeoutMs,
+      int sslPort,
+      String keyStorePath,
+      String keyStorePassword,
+      String trustStorePath,
+      String trustStorePassword)
+  {
+    super(dotLocation, port, baseLocation, heapsterLocation, cacheSize, timeoutMs);
+    _sslPort = sslPort;
+    _keyStorePath = keyStorePath;
+    _keyStorePassword = keyStorePassword;
+    _trustStorePath = trustStorePath;
+    _trustStorePassword = trustStorePassword;
+  }
+
+  @Override
+  protected Connector[] getConnectors(Server server)
+  {
+    SslContextFactory sslContextFactory = new SslContextFactory();
+    sslContextFactory.setKeyStorePath(_keyStorePath);
+    sslContextFactory.setKeyStorePassword(_keyStorePassword);
+    sslContextFactory.setTrustStorePath(_trustStorePath);
+    sslContextFactory.setTrustStorePassword(_trustStorePassword);
+
+
+    HttpConfiguration config = new HttpConfiguration();
+    config.setSecureScheme(HttpScheme.HTTPS.asString());
+    config.addCustomizer(new SecureRequestCustomizer());
+
+    ServerConnector sslConnector =
+        new ServerConnector(_server, new SslConnectionFactory(sslContextFactory, HttpVersion.HTTP_1_1.asString()), new HttpConnectionFactory(config));
+    sslConnector.setPort(_sslPort);
+
+
+    Connector[] httpConnectors = super.getConnectors(server);
+    Connector[] connectors = new Connector[httpConnectors.length + 1];
+
+    int i  = 0;
+    for (Connector c : httpConnectors)
+    {
+      connectors[i++] = c;
+    }
+    connectors[i++] = sslConnector;
+
+    return connectors;
+  }
+}

--- a/subprojects/parseq-tracevis-server/src/main/java/com/linkedin/parseq/TracevisServer.java
+++ b/subprojects/parseq-tracevis-server/src/main/java/com/linkedin/parseq/TracevisServer.java
@@ -32,7 +32,6 @@ public class TracevisServer {
   private final String _dotLocation;
   final GraphvizEngine _graphvizEngine;
 
-  protected Server _server;
 
   public TracevisServer(final String dotLocation, final int port, final Path baseLocation, final Path heapsterLocation,
       final int cacheSize, final long timeoutMs) {
@@ -66,9 +65,9 @@ public class TracevisServer {
 
     _graphvizEngine.start();
 
-    _server = new Server();
-    _server.setAttribute("org.eclipse.jetty.server.Request.maxFormContentSize", -1);
-    _server.setConnectors(getConnectors(_server));
+    Server server = new Server();
+    server.setAttribute("org.eclipse.jetty.server.Request.maxFormContentSize", -1);
+    server.setConnectors(getConnectors(server));
 
     TracePostHandler tracePostHandler = new TracePostHandler(_staticContentLocation.toString());
 
@@ -92,13 +91,13 @@ public class TracevisServer {
         heapsterHandler,
         new DefaultHandler()
         });
-    _server.setHandler(handlers);
+    server.setHandler(handlers);
 
     try {
-      _server.start();
-      _server.join();
+      server.start();
+      server.join();
     } finally {
-      _server.stop();
+      server.stop();
       _graphvizEngine.stop();
       engine.shutdown();
       scheduler.shutdownNow();
@@ -106,8 +105,7 @@ public class TracevisServer {
     }
   }
 
-  protected Connector[] getConnectors(Server server)
-  {
+  protected Connector[] getConnectors(Server server) {
     ServerConnector connector = new ServerConnector(server);
     connector.setPort(_port);
     return new Connector[] { connector };

--- a/subprojects/parseq-tracevis-server/src/main/java/com/linkedin/parseq/TracevisServer.java
+++ b/subprojects/parseq-tracevis-server/src/main/java/com/linkedin/parseq/TracevisServer.java
@@ -6,14 +6,13 @@ import java.nio.file.Path;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
+import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.handler.ContextHandler;
-import org.eclipse.jetty.server.handler.ContextHandlerCollection;
+import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
-import org.eclipse.jetty.util.resource.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +32,8 @@ public class TracevisServer {
   private final String _dotLocation;
   final GraphvizEngine _graphvizEngine;
 
+  protected Server _server;
+
   public TracevisServer(final String dotLocation, final int port, final Path baseLocation, final Path heapsterLocation,
       final int cacheSize, final long timeoutMs) {
     _dotLocation = dotLocation;
@@ -46,6 +47,7 @@ public class TracevisServer {
         Runtime.getRuntime().availableProcessors(), Constants.DEFAULT_REAPER_DELAY_MS,
         Constants.DEFAULT_PROCESS_QUEUE_SIZE);
   }
+
 
   public void start()
       throws Exception {
@@ -64,8 +66,9 @@ public class TracevisServer {
 
     _graphvizEngine.start();
 
-    Server server = new Server(_port);
-    server.setAttribute("org.eclipse.jetty.server.Request.maxFormContentSize", -1);
+    _server = new Server();
+    _server.setAttribute("org.eclipse.jetty.server.Request.maxFormContentSize", -1);
+    _server.setConnectors(getConnectors(_server));
 
     TracePostHandler tracePostHandler = new TracePostHandler(_staticContentLocation.toString());
 
@@ -85,20 +88,28 @@ public class TracevisServer {
         new JhatHandler(engine),
         tracePostHandler,
         traceHandler,
+        new HealthCheckHandler(),
         heapsterHandler,
         new DefaultHandler()
         });
-    server.setHandler(handlers);
+    _server.setHandler(handlers);
 
     try {
-      server.start();
-      server.join();
+      _server.start();
+      _server.join();
     } finally {
-      server.stop();
+      _server.stop();
       _graphvizEngine.stop();
       engine.shutdown();
       scheduler.shutdownNow();
       HttpClient.close();
     }
+  }
+
+  protected Connector[] getConnectors(Server server)
+  {
+    ServerConnector connector = new ServerConnector(server);
+    connector.setPort(_port);
+    return new Connector[] { connector };
   }
 }

--- a/subprojects/parseq-tracevis-server/src/main/java/com/linkedin/parseq/TracevisServerJarMain.java
+++ b/subprojects/parseq-tracevis-server/src/main/java/com/linkedin/parseq/TracevisServerJarMain.java
@@ -22,7 +22,7 @@ public class TracevisServerJarMain {
   public static void main(String[] args) throws Exception {
 
     if (args.length < 1 || args.length > 2) {
-      System.out.println("Incorrect arguments, expecting: DOT_LOCATION <PORT>\n"
+      System.out.println("Incorrect arguments, expecting: DOT_LOCATION <PORT or CONFIG_FILE>\n"
           + "  DOT_LOCATION - location of graphviz dot executable\n"
           + " <PORT>        - optional port number, default is " + Constants.DEFAULT_PORT +
           "OR <CONFIG_FILE> - optional SSL configuration file path for https");

--- a/subprojects/parseq-tracevis-server/src/main/java/com/linkedin/parseq/TracevisServerJarMain.java
+++ b/subprojects/parseq-tracevis-server/src/main/java/com/linkedin/parseq/TracevisServerJarMain.java
@@ -1,6 +1,9 @@
 package com.linkedin.parseq;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URLDecoder;
 import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
@@ -8,8 +11,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Enumeration;
+import java.util.Properties;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.regex.Pattern;
+
 
 public class TracevisServerJarMain {
 
@@ -18,11 +24,12 @@ public class TracevisServerJarMain {
     if (args.length < 1 || args.length > 2) {
       System.out.println("Incorrect arguments, expecting: DOT_LOCATION <PORT>\n"
           + "  DOT_LOCATION - location of graphviz dot executable\n"
-          + "  <PORT>       - optional port number, default is " + Constants.DEFAULT_PORT);
+          + "  <PORT>       - optional port number, default is " + Constants.DEFAULT_PORT +
+          "OR <CONFIG_FILE> - optional SSL configuration file path for https");
       System.exit(1);
     }
+
     final String dotLocation = args[0];
-    final int port = (args.length == 2) ? Integer.parseInt(args[1]) : Constants.DEFAULT_PORT;
 
     String path = TracevisServerJarMain.class.getProtectionDomain().getCodeSource().getLocation().getPath();
     String onwJarFile = URLDecoder.decode(path, "UTF-8");
@@ -43,8 +50,34 @@ public class TracevisServerJarMain {
         }
       }
 
-      new TracevisServer(dotLocation, port, base, base, Constants.DEFAULT_CACHE_SIZE, Constants.DEFAULT_TIMEOUT_MS)
-        .start();
+      Pattern pattern = Pattern.compile("[0-9]{4}");
+      if (args.length == 1 || pattern.matcher(args[1]).matches()) { // support http only
+        int httpPort = args.length == 2 ? Integer.parseInt(args[1]) : Constants.DEFAULT_PORT;
+        new TracevisServer(dotLocation, httpPort, base, base, Constants.DEFAULT_CACHE_SIZE, Constants.DEFAULT_TIMEOUT_MS)
+            .start();
+      } else { // support both http and https
+
+        String fileName = args[1];
+        File configFile = new File(fileName);
+        if (configFile.exists()) {
+          Properties prop = new Properties();
+          InputStream in = new FileInputStream(fileName);
+          prop.load(in);
+
+          // get properties from specified config file
+          int httpPort = Integer.parseInt(prop.getProperty("httpPort", String.valueOf(Constants.DEFAULT_PORT)));
+          int sslPort = Integer.parseInt(prop.getProperty("sslPort", "8081"));
+          String keyStorePath = prop.getProperty("keyStorePath", "");
+          String keyStorePassword = prop.getProperty("keyStorePassword", "");
+          String trustStorePassword = prop.getProperty("trustStorePassword", "");
+          String trustStorePath = prop.getProperty("trustStorePath", "");
+
+          new TracevisHttpsServer(dotLocation, httpPort, base, base, Constants.DEFAULT_CACHE_SIZE, Constants.DEFAULT_TIMEOUT_MS, sslPort,
+              keyStorePath, keyStorePassword, trustStorePath, trustStorePassword).start();
+        } else {
+          throw new RuntimeException("Failed to find config profiles!");
+        }
+      }
 
     } finally {
       //delete base directory recursively


### PR DESCRIPTION
- Add https configuration support
- Add health check for tracevis server
It's a backward compatible change that you can either pass a http port number in command line to start a http server as previously described OR pass a configuration file path to start a https server.