### PR TITLE
Change maven repository link to https

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ script: ./gradlew build
 jdk:
   - oraclejdk8
 
+dist: trusty
+
 #Below skips the installation step completely (https://docs.travis-ci.com/user/customizing-the-build/#Skipping-the-Installation-Step)
 #If we don't skip it Travis runs unnecessary Gradle tasks like './gradlew assemble'
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 v3.0.8
 ------
 
+* Change maven repository link to https
 
 v3.0.7
 ------

--- a/subprojects/parseq-tracevis/README.md
+++ b/subprojects/parseq-tracevis/README.md
@@ -8,15 +8,15 @@ This project includes a trace visualizer for
 Building
 ========
 
-To build the trace visualizer, use `make dist`. This creates a package for the
-trace visualizer at `dist/parseq-tracevis.tar.gz`.
+To build the trace visualizer, use `./gradlew makeDist`. This creates a package for the
+trace visualizer at `build/distributions/parseq-tracevis.tar.gz`.
 
 
 Running the Trace Visualizer
 ============================
 
 To run the trace visualizer, extract `parseq-tracevis.tar.gz` and open
-index.html in a browser. The tool can also be hosted from a web server.
+trace.html in a browser. The tool can also be hosted from a web server.
 
 For coding / debugging, the trace visualizer can also be run from the directory
 that hosts this README.

--- a/subprojects/parseq/build.gradle
+++ b/subprojects/parseq/build.gradle
@@ -6,7 +6,7 @@ archivesBaseName = 'parseq'
 buildscript {
   repositories {
     maven {
-      url "http://repo1.maven.org/maven2/"
+      url "https://repo1.maven.org/maven2/"
     }
   }
 


### PR DESCRIPTION
Use of http links will enable downloading of executable code over insecure channel. For safety reason, we change maven repo to use https link.
Other changes:
- Change travis configuration.
- Update parseq-tracevis README file.