### PR TITLE
Change Regex pattern to match the lambda function description in Zing

### DIFF
--- a/subprojects/parseq-lambda-names/build.gradle
+++ b/subprojects/parseq-lambda-names/build.gradle
@@ -9,7 +9,7 @@ configurations {
 }
 
 dependencies {
-  shadow group: 'com.ea.agentloader', name: 'ea-agent-loader', version: '1.0.2'
+  shadow group: 'com.linkedin.agentloader', name: 'linkedin-agent-loader', version: '1.0.4'
   shadow group: 'org.ow2.asm', name: 'asm-all', version: '5.1'
   testCompile group: 'org.testng', name: 'testng', version: '6.9.9'
 }

--- a/subprojects/parseq-lambda-names/src/main/java/com/linkedin/parseq/lambda/ASMBasedTaskDescriptor.java
+++ b/subprojects/parseq-lambda-names/src/main/java/com/linkedin/parseq/lambda/ASMBasedTaskDescriptor.java
@@ -1,7 +1,7 @@
 package com.linkedin.parseq.lambda;
 
-import com.ea.agentloader.AgentLoader;
-import com.ea.agentloader.ClassPathUtils;
+import com.linkedin.agentloader.AgentLoader;
+import com.linkedin.agentloader.ClassPathUtils;
 import com.linkedin.parseq.TaskDescriptor;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;

--- a/subprojects/parseq-lambda-names/src/main/java/com/linkedin/parseq/lambda/Util.java
+++ b/subprojects/parseq-lambda-names/src/main/java/com/linkedin/parseq/lambda/Util.java
@@ -12,7 +12,7 @@ import org.objectweb.asm.tree.TypeInsnNode;
 
 class Util {
 
-  private static final Pattern LAMBDA_NAME_PATTERN = Pattern.compile("^.*\\$\\$Lambda\\$\\d+$");
+  private static final Pattern LAMBDA_NAME_PATTERN = Pattern.compile("^.*\\$\\$Lambda\\$.*$");
 
   /* package private */
   static boolean isALambdaClassByName(String name) {

--- a/subprojects/parseq-lambda-names/src/test/java/com/linkedin/parseq/lambda/TestUtil.java
+++ b/subprojects/parseq-lambda-names/src/test/java/com/linkedin/parseq/lambda/TestUtil.java
@@ -1,0 +1,18 @@
+package com.linkedin.parseq.lambda;
+
+import org.testng.annotations.Test;
+
+import static com.linkedin.parseq.lambda.Util.*;
+import static org.testng.Assert.*;
+
+
+public class TestUtil {
+  @Test
+  public void testRegexForLambdaClassName() {
+    String lambdaIdentifierInHotSpot = "HelloWorld$$Lambda$1";
+    String lambdaIdentifierInZing = "HelloWorld$$Lambda$lambda$main$0$1310938867";
+
+    assertTrue(isALambdaClassByName(lambdaIdentifierInHotSpot));
+    assertTrue(isALambdaClassByName(lambdaIdentifierInZing));
+  }
+}


### PR DESCRIPTION
In HotSpot (java 8), the dynamic identifier for lambda expression like follows: 
HelloWorld$$Lambda$1 
In Zing (java 8):
HelloWorld$$Lambda$lambda$main$0$1310938867 
In parseq-lambda-names module, it uses a regular expression to filter the lambda function identifier. Since the lambda identifier in Zing can’t match the pattern("^.*\\$\\$Lambda\\$\\d+$"), it would fail to do the following work like, eg, to find the position of that lambda function in source code. 
So change the pattern to match the dynamic identifier in Zing.