### PR TITLE
Guard exception thrown from tracing to avoid unfinished plan.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 v3.0.12
 ------
-
+* Guard exception thrown from tracing code to avoid unfinished plan.
 
 
 v3.0.11

--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/BaseTask.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/BaseTask.java
@@ -252,8 +252,10 @@ public abstract class BaseTask<T> extends DelegatingPromise<T>implements Task<T>
         traceFailure(reason);
       } catch (Throwable ex) {
         LOGGER.warn("Exception thrown in logging trace for failure!", ex);
+      } finally {
+        // guard any exception that may throw from catch block
+        getSettableDelegate().fail(reason);
       }
-      getSettableDelegate().fail(reason);
       return true;
     }
     return false;
@@ -329,9 +331,11 @@ public abstract class BaseTask<T> extends DelegatingPromise<T>implements Task<T>
         traceFailure(error);
       } catch (Throwable ex) {
         LOGGER.warn("Exception thrown in logging trace for failure!", ex);
+      } finally {
+        // guard any exception that may throw from catch block
+        getSettableDelegate().fail(error);
+        taskLogger.logTaskEnd(BaseTask.this, _traceValueProvider);
       }
-      getSettableDelegate().fail(error);
-      taskLogger.logTaskEnd(BaseTask.this, _traceValueProvider);
     }
   }
 

--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/BaseTask.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/BaseTask.java
@@ -248,7 +248,11 @@ public abstract class BaseTask<T> extends DelegatingPromise<T>implements Task<T>
   public boolean cancel(final Exception rootReason) {
     if (transitionCancel(rootReason)) {
       final Exception reason = new CancellationException(rootReason);
-      traceFailure(reason);
+      try {
+        traceFailure(reason);
+      } catch (Throwable ex) {
+        LOGGER.warn("Exception thrown in logging trace for failure!", ex);
+      }
       getSettableDelegate().fail(reason);
       return true;
     }
@@ -320,8 +324,12 @@ public abstract class BaseTask<T> extends DelegatingPromise<T>implements Task<T>
 
   private void fail(final Throwable error, final TaskLogger taskLogger) {
     if (transitionDone()) {
-      appendTaskStackTrace(error);
-      traceFailure(error);
+      try {
+        appendTaskStackTrace(error);
+        traceFailure(error);
+      } catch (Throwable ex) {
+        LOGGER.warn("Exception thrown in logging trace for failure!", ex);
+      }
       getSettableDelegate().fail(error);
       taskLogger.logTaskEnd(BaseTask.this, _traceValueProvider);
     }

--- a/subprojects/parseq/src/test/java/com/linkedin/parseq/TestTasks.java
+++ b/subprojects/parseq/src/test/java/com/linkedin/parseq/TestTasks.java
@@ -48,6 +48,13 @@ import com.linkedin.parseq.promise.SettablePromise;
  */
 public class TestTasks extends BaseEngineTest {
 
+  private static class UnloggableException extends Exception {
+    @Override
+    public String toString() {
+      throw new RuntimeException("Cannot log an UnloggableException!");
+    }
+  }
+
   @Test
   public void testTaskThatThrows() throws InterruptedException {
     final Exception error = new Exception();
@@ -61,6 +68,27 @@ public class TestTasks extends BaseEngineTest {
 
     try {
       runAndWait("TestTasks.testTaskThatThrows", task);
+      fail("task should finish with Exception");
+    } catch (Throwable t) {
+      assertEquals(error, task.getError());
+    }
+
+    assertTrue(task.isFailed());
+  }
+
+  @Test
+  public void testTaskThatThrowsUnloggableException() throws InterruptedException {
+    final Exception error = new UnloggableException();
+
+    final Task<Object> task = new BaseTask<Object>() {
+      @Override
+      protected Promise<Object> run(final Context context) throws Exception {
+        throw error;
+      }
+    };
+
+    try {
+      runAndWait("TestTasks.testTaskThatThrowsUnloggableException", task);
       fail("task should finish with Exception");
     } catch (Throwable t) {
       assertEquals(error, task.getError());


### PR DESCRIPTION
Fix for https://github.com/linkedin/parseq/issues/239