### PR TITLE
Configure bintrayUpload task, add local-release script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 v4.0.1
 ------
 
+* Archives are now uploaded to [LinkedIn's Maven repo on Bintray](https://bintray.com/linkedin/maven)
+  rather than to Maven Central via Sonatype. This involved a major cleanup of the Gradle build scripts.
 * Added the `testArtifact` configuration back for the `:parseq` module as a temporary fix to maintain
   transitive compatibility, though it's now deprecated and should not be used.
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,17 @@
+buildscript {
+  repositories {
+    jcenter()
+  }
+  dependencies {
+    classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
+    classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.4'
+  }
+}
+
+ext {
+  builtByUser = System.getenv('BINTRAY_USER') ?: System.getenv('user.name') ?: 'unknown'
+}
+
 apply from: file("gradle/versioning.gradle")
 
 allprojects { // for all projects including the root project
@@ -5,10 +19,10 @@ allprojects { // for all projects including the root project
   apply plugin: 'eclipse'
   apply plugin: 'maven-publish'
   apply plugin: 'maven'
+  // TODO: remove this once we no longer need ivy publications (adds the "signatures" .ivy configuration)
   apply plugin: 'signing'
 
   version = rootProject.version
-  group = 'com.linkedin.parseq'
 
   repositories {
     mavenCentral()
@@ -24,10 +38,9 @@ idea {
 }
 
 subprojects {
-  archivesBaseName = project.name
-
   if (!it.name.equals("parseq-tracevis")) {
     apply plugin: 'java'
+    apply plugin: 'java-library'
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
 
@@ -53,11 +66,12 @@ subprojects {
     }
 
     // configure MANIFEST
+    // TODO: unnecessary and volatile attributes affect caching and should be removed
     jar {
       manifest {
         attributes("Created-By": "Gradle",
             "Version": version,
-            "Built-By": sonatypeUsername,
+            "Built-By": project.rootProject.ext.builtByUser,
             "Build-JDK": JavaVersion.current())
       }
     }
@@ -66,6 +80,7 @@ subprojects {
     javadoc {
       options.use = true
       options.author = true
+      // TODO: update date to be dynamically set
       options.bottom = "Copyright &#169; 2018. All rights reserved."
       options.classpath += file("${project.projectDir.absolutePath}/src/main/java")
       options.links("https://docs.oracle.com/javase/8/docs/api/")
@@ -81,69 +96,13 @@ subprojects {
     }
   }
 
-  // Not include parseq-examples and parseq-legacy-examples, since we don't need to publish their jar files
+  // Don't include parseq-examples and parseq-legacy-examples, since we don't need to publish their jar files
   afterEvaluate {
     if (it.name.startsWith('parseq') && !it.name.endsWith('examples') && !it.name.endsWith('tracevis')) {
       artifacts {
         archives jar
         archives packageJavadoc
         archives packageSources
-      }
-    }
-    if (it.name.equals("parseq-examples") || it.name.equals("parseq-legacy-examples")) {
-      project.tasks.uploadArchives.enabled = false
-    }
-  }
-
-  // sign up
-  if (project.hasProperty('ossRelease')) {
-    signing {
-      required = { gradle.taskGraph.hasTask("uploadArchives") }
-      sign configurations.archives
-    }
-  }
-
-  // publish to maven and local ivy repo
-  uploadArchives {
-    repositories {
-      ivy { url "file:$rootDir/build/ivy-repo" }
-
-      mavenDeployer {
-        if (project.hasProperty('ossRelease')) {
-          // pom signature
-          beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-
-          repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-            authentication(userName: sonatypeUsername, password: sonatypePassword)
-          }
-
-          snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots") {
-            authentication(userName: sonatypeUsername, password: sonatypePassword)
-          }
-        } else {
-          //Useful for local testing. If not useful, we should delete this line:
-          repository(url: "file:$rootDir/build/mvn-repo")
-        }
-
-        pom.project {
-          name project.name
-          packaging 'jar'
-          url 'http://github.com/linkedin/parseq'
-
-          scm {
-            url 'git@github.com:linkedin/parseq.git'
-            connection 'scm:git:git@github.com:linkedin/parseq.git'
-            developerConnection 'scm:git:git@github.com:linkedin/parseq.git'
-          }
-
-          licenses {
-            license {
-              name 'The Apache Software License, Version 2.0'
-              url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-              distribution 'repo'
-            }
-          }
-        }
       }
     }
   }
@@ -182,4 +141,20 @@ task runTracevisServer (dependsOn:':parseq-tracevis-server:build') {
       logger.error('Can not find dot tools, please install it or check the docLocation!')
     }
   }
+}
+
+subprojects { p ->
+  if (!p.name.endsWith('examples')) {
+    p.afterEvaluate {
+      p.apply from: "$rootDir/gradle/maven.gradle"
+    }
+    p.apply from: "$rootDir/gradle/bintray.gradle"
+  }
+}
+
+// TODO: remove once ivy publications are no longer required
+// Clean the project's local ivy repo before publishing to prevent conflicts
+project.tasks.uploadArchives.doFirst {
+  logger.lifecycle "Cleaning local ivy repo: $rootDir/build/ivy-repo"
+  delete(file("$rootDir/build/ivy-repo"))
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,3 @@
 version=4.0.0
-
-sonatypeUsername=please_set_in_home_dir_if_uploading_to_maven_central
-sonatypePassword=please_set_in_home_dir_if_uploading_to_maven_central
-
-#signing.keyId=YourKeyId
-#signing.password=YourPublicKeyPassword
-#signing.secretKeyRingFile=PathToYourKeyRingFile
+group=com.linkedin.parseq
+org.gradle.parallel=true

--- a/gradle/bintray.gradle
+++ b/gradle/bintray.gradle
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 LinkedIn, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * The purpose of this script is to configure the following tasks for a given sub-project:
+ * - bintrayUpload: uploads, signs, and publishes all artifacts; depends on...
+ *   - assertArtifactsExist: asserts that the required JAR artifacts are present
+ *   - assertBintrayCredentialsExist: asserts that Bintray credentials are present as environment variables
+ */
+apply plugin: 'com.jfrog.bintray'
+
+final String bintrayUserEnv = 'BINTRAY_USER'
+final String bintrayKeyEnv = 'BINTRAY_KEY'
+
+def bintrayUser = System.getenv(bintrayUserEnv)
+def bintrayKey = System.getenv(bintrayKeyEnv)
+
+bintray {
+  user = bintrayUser
+  key = bintrayKey
+  publications = ['release']
+  publish = true
+  pkg {
+    userOrg = 'linkedin'
+    repo = 'maven'
+    name = 'parseq'
+    websiteUrl = 'https://github.com/linkedin/parseq'
+    issueTrackerUrl = 'https://github.com/linkedin/parseq/issues'
+    vcsUrl = 'https://github.com/linkedin/parseq.git'
+    githubRepo = 'linkedin/parseq'
+    licenses = ['Apache-2.0']
+    version {
+      vcsTag = "v${project.version}"
+      gpg {
+        sign = true
+      }
+    }
+  }
+}
+
+task assertArtifactsExist() {
+  doLast {
+    final Set<File> missingArtifacts = configurations.archives.allArtifacts.file.findAll { !it.exists() }
+    if (missingArtifacts) {
+      throw new GradleException("Cannot perform Bintray upload. The project likely hasn't been built. Missing artifacts ${missingArtifacts}")
+    }
+  }
+}
+
+task assertBintrayCredentialsExist() {
+  doLast {
+    if (!bintrayUser || !bintrayKey) {
+      throw new GradleException("Cannot perform Bintray upload. Missing '${bintrayUserEnv}' or '${bintrayKeyEnv}' environment variable.")
+    }
+  }
+}
+
+bintrayUpload.dependsOn assertArtifactsExist, assertBintrayCredentialsExist, 'generatePomFileForReleasePublication'

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 LinkedIn, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * The purpose of this script is to configure the following tasks for a given sub-project:
+ * - generatePomFileForReleasePublication: generates the "release" Maven publication (.pom), needed for bintrayUpload
+ * - publishReleasePublicationToMavenLocal: publishes the "release" publication to Maven local
+ *
+ * This script should be applied after sub-projects are evaluated to ensure that sub-project archives have been
+ * configured and extra properties have been set.
+ */
+final boolean isJavaPublication = !project.name.equals('parseq-tracevis')
+
+def pomConfig = {
+  resolveStrategy = Closure.DELEGATE_FIRST // needed for the description to be included for some reason
+  if (isJavaPublication) {
+    packaging 'jar'
+  }
+  name project.name // sub-project name
+  description project.ext.description
+  url 'http://github.com/linkedin/parseq'
+  licenses {
+    license {
+      name 'The Apache Software License, Version 2.0'
+      url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+      distribution 'repo'
+    }
+  }
+  developers {
+    // Add developers common to all sub-projects
+    developer {
+      id 'jodzga'
+      name 'Jaroslaw Odzga'
+      email 'jodzga@linkedin.com'
+    }
+    // Add developers specific to this sub-project
+    if (project.ext.has('developers')) {
+      project.ext.developers.forEach { info ->
+        developer {
+          id info.id
+          name info.name
+          email info.email
+        }
+      }
+    }
+  }
+  scm {
+    connection 'scm:git:git@github.com:linkedin/parseq.git'
+    developerConnection 'scm:git:git@github.com:linkedin/parseq.git'
+    url 'git@github.com:linkedin/parseq.git'
+  }
+}
+
+publishing {
+  publications {
+    release(MavenPublication) {
+      if (isJavaPublication) {
+        from components.java
+        // Add all extra archives (sources, javadoc, any custom archives e.g. jar-with-dependencies)
+        project.configurations.archives.allArtifacts.findAll { it.classifier }.forEach { artifact it }
+      } else {
+        // Add all tracevis artifacts
+        project.configurations.tracevisArtifacts.allArtifacts.forEach { artifact it }
+      }
+      groupId project.group
+      artifactId project.name // sub-project name
+      version project.version
+      pom.withXml {
+        def root = asNode()
+        def children = root.children()
+
+        // Prefer appending POM info before dependencies for readability (helps with debugging)
+        if (children.last().name().toString().endsWith('dependencies')) {
+          children.get(children.size() - 2) + pomConfig
+        } else {
+          children.last() + pomConfig
+        }
+      }
+    }
+  }
+}
+
+// TODO: remove once ivy publications are no longer required
+// Publish to project's local ivy repo
+uploadArchives {
+  repositories {
+    ivy { url "file:$rootDir/build/ivy-repo" }
+  }
+}

--- a/scripts/local-release
+++ b/scripts/local-release
@@ -1,0 +1,30 @@
+#!/bin/sh
+# The purpose of this script is to publish artifacts to ~/local-repo
+
+if [ ! -f gradle.properties ]; then
+  echo 'Could not find gradle.properties. Run this command from the root of the project.'
+  exit 1
+fi
+
+if [ ! -d "$HOME" ]; then
+  echo 'Cannot perform local release, $HOME is not set to a valid directory.'
+  exit 1
+fi
+
+LOCAL_REPO="${HOME}/local-repo"
+
+if [ ! -d $LOCAL_REPO ]; then
+  mkdir $LOCAL_REPO
+fi
+
+VERSION=$(awk 'BEGIN { FS = "=" }; $1 == "version" { print $2 }' gradle.properties | awk '{ print $1 }')
+echo "Publishing parseq $VERSION to ${LOCAL_REPO}..."
+
+# Publish artifacts to Maven local, but override the repo path as ~/local-repo
+./gradlew -Dmaven.repo.local=$LOCAL_REPO -Prelease publishReleasePublicationToMavenLocal
+
+if [ $? -eq 0 ]; then
+  echo "Published parseq $VERSION to $LOCAL_REPO"
+else
+  exit 1
+fi

--- a/scripts/release
+++ b/scripts/release
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+echo 'This script is outdated and should not be used'
+exit 2
+
 if test ! -f version.properties
 then
     echo >&2 Could not find version.properties. Run this command from the root of the project.

--- a/subprojects/parseq-batching/build.gradle
+++ b/subprojects/parseq-batching/build.gradle
@@ -1,4 +1,6 @@
-description = """Provides convenient API for creating automatically batched tasks"""
+ext {
+  description = """Provides a convenient API for creating automatically batched tasks"""
+}
 
 
 dependencies {
@@ -7,22 +9,4 @@ dependencies {
   testCompile project(':parseq-test-api')
   testCompile group: 'org.testng', name: 'testng', version:'6.9.9'
   testCompile group: 'org.slf4j', name: 'slf4j-simple', version:'1.7.12'
-}
-
-
-uploadArchives {
-  repositories {
-    mavenDeployer {
-      pom.project {
-        description description
-        developers {
-          developer {
-            id 'jodzga'
-            name 'Jaroslaw Odzga'
-            email 'jodzga@linkedin.com'
-          }
-        }
-      }
-    }
-  }
 }

--- a/subprojects/parseq-benchmark/build.gradle
+++ b/subprojects/parseq-benchmark/build.gradle
@@ -1,4 +1,6 @@
-description = """Set of benchmarks for ParSeq"""
+ext {
+  description = """Set of benchmarks for ParSeq"""
+}
 
 dependencies {
   compile project(':parseq-batching')
@@ -6,15 +8,15 @@ dependencies {
   compile group: 'org.slf4j', name: 'slf4j-simple', version:'1.7.12'
 }
 
-
 task fatJar(type: Jar) {
+  mustRunAfter ':parseq:jar' // for some reason, gradle can't figure out this transitive dependency
   classifier = 'jar-with-dependencies'
   from { configurations.compile.collect { it.isDirectory()? it : zipTree(it) } }
   with jar
   manifest {
     attributes("Created-By": "Gradle",
         "Version": version,
-        "Built-By": sonatypeUsername,
+        "Built-By": project.rootProject.ext.builtByUser,
         "Build-JDK": JavaVersion.current())
     attributes 'Main-Class': 'com.linkedin.parseq.PerfLarge'
   }
@@ -25,26 +27,6 @@ task executeJava(type: JavaExec) {
   classpath = sourceSets.main.runtimeClasspath
 }
 
-
-
 artifacts {
   archives fatJar
-}
-
-uploadArchives {
-  repositories {
-    mavenDeployer {
-      pom.project {
-        description description
-
-        developers {
-          developer {
-            id 'jodzga'
-            name 'Jaroslaw Odzga'
-            email 'jodzga@linkedin.com'
-          }
-        }
-      }
-    }
-  }
 }

--- a/subprojects/parseq-examples/build.gradle
+++ b/subprojects/parseq-examples/build.gradle
@@ -1,4 +1,6 @@
-description = """parseq-examples is for illustrating how to use parseq API"""
+ext {
+  description = """parseq-examples illustrates how to use the ParSeq API"""
+}
 
 
 dependencies {
@@ -6,7 +8,6 @@ dependencies {
   compile project(":parseq-batching")
   compile project(":parseq-lambda-names")
 }
-
 
 //Since some classes at times use deprecated apis we are ignoring the deprecation warning here.
 compileJava.options.compilerArgs += '-Xlint:-deprecation'

--- a/subprojects/parseq-exec/build.gradle
+++ b/subprojects/parseq-exec/build.gradle
@@ -1,20 +1,3 @@
-description = """Integrates ParSeq with Java Process API"""
-
-
-uploadArchives {
-  repositories {
-    mavenDeployer {
-      pom.project {
-        description description
-
-        developers {
-          developer {
-            id 'jodzga'
-            name 'Jaroslaw Odzga'
-            email 'jodzga@linkedin.com'
-          }
-        }
-      }
-    }
-  }
+ext {
+  description = """Integrates ParSeq with the Java Process API"""
 }

--- a/subprojects/parseq-http-client/build.gradle
+++ b/subprojects/parseq-http-client/build.gradle
@@ -1,23 +1,7 @@
-description = """Integrates ParSeq with Async Http Client library"""
+ext {
+    description = """Integrates ParSeq with the Async Http Client library"""
+}
 
 dependencies {
     compile group: 'com.ning', name: 'async-http-client', version:'1.9.21'
-}
-
-uploadArchives {
-  repositories {
-    mavenDeployer {
-      pom.project {
-        description description
-
-        developers {
-          developer {
-            id 'jodzga'
-            name 'Jaroslaw Odzga'
-            email 'jodzga@linkedin.com'
-          }
-        }
-      }
-    }
-  }
 }

--- a/subprojects/parseq-lambda-names/build.gradle
+++ b/subprojects/parseq-lambda-names/build.gradle
@@ -1,7 +1,8 @@
+ext {
+  description = """Finds source code locations and infers operations for lambda expressions"""
+}
+
 apply plugin: 'com.github.johnrengelman.shadow'
-
-
-description = """Finds source code location and infers operation for lambda expressions"""
 
 
 configurations {
@@ -18,15 +19,6 @@ sourceSets.main.compileClasspath += configurations.shadow + sourceSets.main.comp
 
 javadoc.classpath += configurations.shadow + sourceSets.main.compileClasspath
 
-buildscript {
-  repositories {
-    jcenter()
-  }
-  dependencies {
-    classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.4'
-  }
-}
-
 shadowJar {
   configurations += [project.configurations.shadow]
   classifier = null
@@ -34,29 +26,9 @@ shadowJar {
 }
 
 jar {
+  finalizedBy shadowJar // The shadowJar task basically overwrites the output of the jar task (kind of hacky)
   manifest {
     attributes 'Agent-Class': 'com.linkedin.parseq.lambda.ASMBasedTaskDescriptor$Agent'
-  }
-}
-
-uploadArchives.dependsOn shadowJar
-assemble.dependsOn shadowJar
-
-uploadArchives {
-  repositories {
-    mavenDeployer {
-      pom.project {
-        description description
-
-        developers {
-          developer {
-            id 'jodzga'
-            name 'Jaroslaw Odzga'
-            email 'jodzga@linkedin.com'
-          }
-        }
-      }
-    }
   }
 }
 

--- a/subprojects/parseq-legacy-examples/build.gradle
+++ b/subprojects/parseq-legacy-examples/build.gradle
@@ -1,1 +1,3 @@
-description = """parseq-legacy-examples"""
+ext {
+  description = """parseq-legacy-examples"""
+}

--- a/subprojects/parseq-restli-client/build.gradle
+++ b/subprojects/parseq-restli-client/build.gradle
@@ -1,6 +1,8 @@
-apply plugin: 'antlr'
+ext {
+    description = """Provides a convenient API for creating automatically batched tasks""" // TODO: is this accurate?
+}
 
-description = """Provides convenient API for creating automatically batched tasks"""
+apply plugin: 'antlr'
 
 
 dependencies {
@@ -28,22 +30,4 @@ dependencies {
 generateGrammarSource {
   source = fileTree(dir: '${projectDir}/src/main/antlr4')
   outputDirectory = file("${projectDir}/src/main/java")
-}
-
-uploadArchives {
-  repositories {
-    mavenDeployer {
-      pom.project {
-        description description
-
-        developers {
-          developer {
-            id 'jodzga'
-            name 'Jaroslaw Odzga'
-            email 'jodzga@linkedin.com'
-          }
-        }
-      }
-    }
-  }
 }

--- a/subprojects/parseq-test-api/build.gradle
+++ b/subprojects/parseq-test-api/build.gradle
@@ -1,4 +1,6 @@
-description = '''Provides test fixtures for writing ParSeq-based integration/unit tests'''
+ext {
+  description = '''Provides test fixtures for writing ParSeq-based integration/unit tests'''
+}
 
 dependencies {
   compile group: "org.testng", name: "testng", version: "6.9.9"
@@ -7,21 +9,4 @@ dependencies {
 
 javadoc {
   options.use = false
-}
-
-uploadArchives {
-  repositories {
-    mavenDeployer {
-      pom.project {
-        description description
-        developers {
-          developer {
-            id 'jodzga'
-            name 'Jaroslaw Odzga'
-            email 'jodzga@linkedin.com'
-          }
-        }
-      }
-    }
-  }
 }

--- a/subprojects/parseq-tracevis-server/build.gradle
+++ b/subprojects/parseq-tracevis-server/build.gradle
@@ -1,4 +1,6 @@
-description = """Serves tracevis tool capable of rendering graphviz diagrams"""
+ext {
+  description = """Serves the tracevis tool for rendering graphviz diagrams"""
+}
 
 def jettyVersion = '9.3.0.v20150612'
 
@@ -35,7 +37,7 @@ task fatJar(type: Jar, dependsOn: ':parseq-tracevis:makeDist') {
   manifest {
     attributes("Created-By": "Gradle",
         "Version": version,
-        "Built-By": sonatypeUsername,
+        "Built-By": project.rootProject.ext.builtByUser,
         "Build-JDK": JavaVersion.current())
     attributes 'Main-Class': 'com.linkedin.parseq.TracevisServerJarMain'
   }
@@ -43,22 +45,4 @@ task fatJar(type: Jar, dependsOn: ':parseq-tracevis:makeDist') {
 
 artifacts {
   archives fatJar
-}
-
-uploadArchives {
-  repositories {
-    mavenDeployer {
-      pom.project {
-        description description
-
-        developers {
-          developer {
-            id 'jodzga'
-            name 'Jaroslaw Odzga'
-            email 'jodzga@linkedin.com'
-          }
-        }
-      }
-    }
-  }
 }

--- a/subprojects/parseq-tracevis/build.gradle
+++ b/subprojects/parseq-tracevis/build.gradle
@@ -1,6 +1,13 @@
-description = '''A trace visualizer for ParSeq traces.'''
+ext {
+  description = '''A trace visualizer for ParSeq traces.'''
+  developers = [
+    [id: 'cpettitt', name: 'Chris Pettitt', email: 'cpettitt@linkedin.com'],
+    [id: 'ckchan', name: 'Chi Kit Chan', email: 'ckchan@linkedin.com']
+  ]
+}
 
-apply plugin: 'com.moowork.node'
+apply plugin: 'com.github.node-gradle.node'
+
 
 node {
   // Version of node to use.
@@ -28,7 +35,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath "com.moowork.gradle:gradle-node-plugin:1.2.0"
+    classpath 'com.github.node-gradle:gradle-node-plugin:2.2.3'
   }
 }
 
@@ -281,45 +288,4 @@ build.dependsOn makeDist
 
 artifacts {
   tracevisArtifacts makeDist
-  //archives makeDist
-  if (project.hasProperty('ossRelease')) {
-    project.afterEvaluate {
-      // gradle is broken for extensions that contain a dot, so we must be explicit about the name of the .asc file
-      project.signArchives.singleSignature.type = 'tar.gz.asc'
-    }
-  }
-}
-
-configurations.archives.artifacts.with { archives ->
-  archives.findAll { !(it.file =~ 'tar.gz' || it.file=~ 'tar.gz.asc') }.each {
-    remove(it) }
-}
-
-
-uploadArchives {
-  repositories {
-    mavenDeployer {
-      pom.project {
-        description description
-
-        developers {
-          developer {
-            id 'cpettitt'
-            name 'Chris Pettitt'
-            email 'cpettitt@linkedin.com'
-          }
-          developer {
-            id 'ckchan'
-            name 'Chi Kit Chan'
-            email 'ckchan@linkedin.com<'
-          }
-          developer {
-            id 'jodzga'
-            name 'Jaroslaw Odzga'
-            email 'jodzga@linkedin.com'
-          }
-        }
-      }
-    }
-  }
 }

--- a/subprojects/parseq-zk-client/build.gradle
+++ b/subprojects/parseq-zk-client/build.gradle
@@ -1,4 +1,9 @@
-description = """Integrates ParSeq with Apache ZooKeeper Library"""
+ext {
+  description = """Integrates ParSeq with the Apache ZooKeeper Library"""
+  developers = [
+    [id: 'axu', name: 'Ang Xu', email: 'axu@linkedin.com']
+  ]
+}
 
 
 dependencies {
@@ -6,22 +11,4 @@ dependencies {
   testCompile project(':parseq-test-api')
   testCompile group: 'org.testng', name: 'testng', version:'6.9.9'
   testCompile group: 'com.linkedin.pegasus', name: 'd2', version:'2.6.0'
-}
-
-uploadArchives {
-  repositories {
-    mavenDeployer {
-      pom.project {
-        description description
-
-        developers {
-          developer {
-            id 'axu'
-            name 'Ang Xu'
-            email 'axu@linkedin.com'
-          }
-        }
-      }
-    }
-  }
 }

--- a/subprojects/parseq/build.gradle
+++ b/subprojects/parseq/build.gradle
@@ -1,6 +1,7 @@
-description = '''ParSeq project core code'''
+ext {
+  description = '''ParSeq project core code'''
+}
 
-archivesBaseName = 'parseq'
 
 //TODO avoid buildscript dependency
 buildscript {
@@ -42,26 +43,6 @@ dependencies {
   // TODO: remove in parseq 5
   testArtifact project(':parseq-test-api')
 }
-
-// publish to maven
-uploadArchives {
-  repositories {
-    mavenDeployer {
-      pom.artifactId = 'parseq'
-      pom.project {
-        description description
-        developers {
-          developer {
-            id 'jodzga'
-            name 'Jaroslaw Odzga'
-            email 'jodzga@linkedin.com'
-          }
-        }
-      }
-    }
-  }
-}
-
 
 // When update the template and data in codegen, need to run this task before gradle build task
 task generateFmppSources {


### PR DESCRIPTION
Removes the old `MavenDeployer` setup, adds a new OSS
publishing mechanism using the Bintray Gradle plugin,
with the top-level publishing task being `bintrayUpload`.
Adds the `local-release` script which publishes Maven
artifacts to `~/local-release.

**NOTE:** Build failing because of nodejs.org server errors, going to force re-build tomorrow.