### PR TITLE
Configure Travis to only build on master and tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,9 @@ dist: trusty
 #If we don't skip it Travis runs unnecessary Gradle tasks like './gradlew assemble'
 install:
  - true
+
+# Only build on master and release tags
+branches:
+  only:
+  - master
+  - /^v\d+\.\d+\.\d+$/


### PR DESCRIPTION
Currently, feature branch PRs trigger two builds: one for the branch and one for the PR.
This attempts to remove that redundancy by only building on the master branch as well
as release tags.