### PR TITLE
Add testArtifact configuration back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 v4.0.1
 ------
 
+* Added the `testArtifact` configuration back for the `:parseq` module as a temporary fix to maintain
+  transitive compatibility, though it's now deprecated and should not be used.
+
 v4.0.0
 ------
 

--- a/subprojects/parseq/build.gradle
+++ b/subprojects/parseq/build.gradle
@@ -23,6 +23,10 @@ configurations {
     description "bootstrapping dependencies"
     visible = false
   }
+  // Maintains transitive consumer compatibility for consumers of parseq 3. TODO: remove in parseq 5
+  testArtifact {
+    description "this is deprecated and will be removed, please depend on parseq-test-api instead"
+  }
 }
 
 dependencies {
@@ -34,6 +38,9 @@ dependencies {
   testCompile project(':parseq-test-api')
   testCompile group: "org.testng", name: "testng", version: "6.9.9"
   testCompile group: "org.slf4j", name: "slf4j-log4j12", version: "1.7.25"
+
+  // TODO: remove in parseq 5
+  testArtifact project(':parseq-test-api')
 }
 
 // publish to maven


### PR DESCRIPTION
Temporary fix to maintain compatibility with transitive consumers who
are still explicitly depending on the testArtifact configuration of
the parseq module. This simply tacks on the parseq-test-api dependency.

Steps to reproduce error:
1. Consumer A depends directly on `parseq-test-api@4.0.0`
2. Consumer B depends directly on Consumer A, yet also depends directly on `parseq@3.*` using the `testArtifact` configuration.
3. Consumer B's dependency on `parseq` will be bumped up to `4.0.0`, which will cause an error because the `testArtifact` configuration doesn't exist for `parseq@4.0.0`.

Without this fix, transitive consumers of parseq 4.0.0 may still be explicitly depending on the `testArtifact` configuration of the `parseq` module, which would result in an error like this:

```
Could not resolve all files for configuration ':consumer:testCompileClasspath'.
   > Could not resolve com.linkedin.parseq:parseq:4.0.0-SNAPSHOT.
Required by:
    project :consumer
      > Project :consumer declares a dependency from configuration 'testCompile' to configuration 'testArtifact' which is not declared in the descriptor for com.linkedin.parseq:parseq:4.0.0-SNAPSHOT.
```