### PR TITLE
Prep v4.1.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-v4.0.2
+v4.1.1
+------
+
+v4.1.0
 ------
 
 * Archives are now uploaded to [LinkedIn's Maven repo on Bintray](https://bintray.com/linkedin/maven)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=4.0.1
+version=4.1.0
 group=com.linkedin.parseq
 org.gradle.parallel=true


### PR DESCRIPTION
Reasoning for bumping the minor version: the changes to the Gradle build scripts and the way we publish artifacts have been dramatically altered. Although I have shown that the published archives will be compatible, I'm bumping the minor version to be safe as per semver.