### PR TITLE
fix mac build issue for tracevis

### DIFF
--- a/subprojects/parseq-tracevis/package.json
+++ b/subprojects/parseq-tracevis/package.json
@@ -9,7 +9,7 @@
     "jshint": "~2.1.11",
     "istanbul": "~0.1.44",
     "mocha": "1.2.x",
-    "phantomjs": "~1.9.2-2",
+    "phantomjs": "^2.1.7",
     "uglify-js": "2.6.0"
   },
   "dependencies": {


### PR DESCRIPTION
Upgrading phantomjs to solve one of the build issue in testCov, fails on mac only since c++ libs used to build are different on mac. Other issues relating to installation failure:

Root cause is contextify being no longer support as it is merged native to node. 
Permanent fix is upgrade node and package dependencies. 

for now will have use below patches(one time). I will add specific cmds to developer guide.

Refer:
https://github.com/nodejs/node-gyp/issues/569
https://github.com/nodejs/node-gyp/issues/469