### PR TITLE
Set up automated releases, improve helper scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,30 @@
 language: java
-
-script: ./gradlew build
-
 jdk:
   - oraclejdk8
 
+# Anything after trusty doesn't have Java 8
 dist: trusty
 
-#Below skips the installation step completely (https://docs.travis-ci.com/user/customizing-the-build/#Skipping-the-Installation-Step)
-#If we don't skip it Travis runs unnecessary Gradle tasks like './gradlew assemble'
-install:
- - true
+# Below skips the installation step completely (https://docs.travis-ci.com/user/customizing-the-build/#Skipping-the-Installation-Step)
+# If we don't skip it Travis runs unnecessary Gradle tasks like './gradlew assemble'
+install: true
 
-# Only build on master and release tags
+# Build and test each commit on master and each PR to master
+script: ./gradlew build
 branches:
   only:
   - master
-  - /^v\d+\.\d+\.\d+$/
+
+# Publish a new version on tag push
+deploy:
+  provider: script
+  script: scripts/travis/publish-tag.sh
+  on:
+    tags: true
+
+# Send email notifications to the user associated with a tag deployment
+notifications:
+  email:
+    if: tag IS present
+    on_failure: always
+    on_success: always

--- a/build.gradle
+++ b/build.gradle
@@ -8,10 +8,6 @@ buildscript {
   }
 }
 
-ext {
-  builtByUser = System.getenv('BINTRAY_USER') ?: System.getenv('user.name') ?: 'unknown'
-}
-
 apply from: file("gradle/versioning.gradle")
 
 allprojects { // for all projects including the root project
@@ -71,7 +67,6 @@ subprojects {
       manifest {
         attributes("Created-By": "Gradle",
             "Version": version,
-            "Built-By": project.rootProject.ext.builtByUser,
             "Build-JDK": JavaVersion.current())
       }
     }

--- a/scripts/help-text/local-release.txt
+++ b/scripts/help-text/local-release.txt
@@ -1,0 +1,11 @@
+Usage: ./scripts/local-release [OPTION]...
+Publishes ParSeq's Maven artifacts to ~/local-repo.
+This script must be run from the root project directory.
+
+Options:
+  -h, --help                    print this help text and exit
+  -s, --snapshot                release a snapshot version
+
+Examples:
+  ./scripts/local-release       publish x.y.z artifacts to ~/local-repo
+  ./scripts/local-release -s    publish x.y.z-SNAPSHOT artifacts to ~/local-repo

--- a/scripts/help-text/release.txt
+++ b/scripts/help-text/release.txt
@@ -1,0 +1,11 @@
+Usage: ./scripts/release [OPTION]... [TARGET_COMMIT]
+Releases a new version of ParSeq by creating and pushing a tag at TARGET_COMMIT (defaults to HEAD).
+This script must be run from the root project directory.
+
+Options:
+  -h, --help                    print this help text and exit
+
+Examples:
+  ./scripts/release             create and push a release tag at HEAD
+  ./scripts/release 0a1b2c3     create and push a release tag at commit 0a1b2c3
+  ./scripts/release master^^    create and push a release tag at two commits before the head of master

--- a/scripts/local-release
+++ b/scripts/local-release
@@ -1,27 +1,50 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # The purpose of this script is to publish artifacts to ~/local-repo
 
-if [ ! -f gradle.properties ]; then
-  echo 'Could not find gradle.properties. Run this command from the root of the project.'
-  exit 1
+# Ensure that the script is being run from the root project directory
+PROPERTIES_FILE='gradle.properties'
+if [ ! -f "$PROPERTIES_FILE" ]; then
+  echo "Could not find $PROPERTIES_FILE, please run this script from the root project directory."
+  exit 2
 fi
+
+# Process CLI arguments
+EXTRA_PROPERTY='-Prelease'
+for ARG in "$@"; do
+  if [ "$ARG" = '-h' ] || [ "$ARG" = '--help' ]; then
+    cat ./scripts/help-text/local-release.txt
+    exit 0
+  elif [ "$ARG" = '-s' ] || [ "$ARG" = '--snapshot' ]; then
+    EXTRA_PROPERTY='-Psnapshot'
+  else
+    echo "Unrecognized option: $ARG"
+    echo ''
+    cat ./scripts/help-text/local-release.txt
+    exit 2
+  fi
+done
 
 if [ ! -d "$HOME" ]; then
   echo 'Cannot perform local release, $HOME is not set to a valid directory.'
   exit 1
 fi
 
+# Create ~/local-repo if it doesn't already exist
 LOCAL_REPO="${HOME}/local-repo"
-
 if [ ! -d $LOCAL_REPO ]; then
   mkdir $LOCAL_REPO
 fi
 
-VERSION=$(awk 'BEGIN { FS = "=" }; $1 == "version" { print $2 }' gradle.properties | awk '{ print $1 }')
+# Determine the version to be released, adding the snapshot suffix if appropriate
+VERSION=$(awk 'BEGIN { FS = "=" }; $1 == "version" { print $2 }' $PROPERTIES_FILE | awk '{ print $1 }')
+if [ "$EXTRA_PROPERTY" = '-Psnapshot' ] && [[ "$VERSION" != *-SNAPSHOT ]]; then
+  VERSION="${VERSION}-SNAPSHOT"
+fi
+
 echo "Publishing parseq $VERSION to ${LOCAL_REPO}..."
 
 # Publish artifacts to Maven local, but override the repo path as ~/local-repo
-./gradlew -Dmaven.repo.local=$LOCAL_REPO -Prelease publishReleasePublicationToMavenLocal
+./gradlew -Dmaven.repo.local=$LOCAL_REPO $EXTRA_PROPERTY publishReleasePublicationToMavenLocal
 
 if [ $? -eq 0 ]; then
   echo "Published parseq $VERSION to $LOCAL_REPO"

--- a/scripts/local-release
+++ b/scripts/local-release
@@ -9,6 +9,7 @@ if [ ! -f "$PROPERTIES_FILE" ]; then
 fi
 
 # Process CLI arguments
+# TODO: add an argument to override the repo location
 EXTRA_PROPERTY='-Prelease'
 for ARG in "$@"; do
   if [ "$ARG" = '-h' ] || [ "$ARG" = '--help' ]; then

--- a/scripts/release
+++ b/scripts/release
@@ -1,54 +1,77 @@
-#!/bin/sh
+#!/usr/bin/env bash
+# The purpose of this script is to release the current version by creating and pushing a tag
 
-echo 'This script is outdated and should not be used'
-exit 2
+REMOTE='origin'
 
-if test ! -f version.properties
-then
-    echo >&2 Could not find version.properties. Run this command from the root of the project.
-    exit 1
-fi
-VERSION=`sed -n 's|version=||p' version.properties`
-
-echo Attempting to publish: $VERSION
-echo
-
-JAVA_VERSION=`java -version 2>&1 | head -1`
-echo $JAVA_VERSION | grep -q '1\.6\.'
-if test $? -ne 0
-then
-    echo "ParSeq releases can only be built using a Java 1.6 JDK."
-    echo "Java reports its version to be: $JAVA_VERSION"
-    exit 1
+# Ensure that the script is being run from the root project directory
+PROPERTIES_FILE='gradle.properties'
+if [ ! -f "$PROPERTIES_FILE" ]; then
+  echo "Could not find $PROPERTIES_FILE, please run this script from the root project directory."
+  exit 2
 fi
 
-DIRTY="`git status --porcelain || echo FAIL`"
-if test -n "$DIRTY"
-then
-    echo "Dirty index or working tree. Use git status to check." 2>&1
-    echo "After resolution, run this command again." 2>&1
-    exit 1
+# Process CLI arguments
+TARGET="HEAD"
+for ARG in "$@"; do
+  if [ "$ARG" = '-h' ] || [ "$ARG" = '--help' ]; then
+    cat ./scripts/help-text/release.txt
+    exit 0
+  else
+    TARGET="$1"
+  fi
+done
+
+# Determine and verify the target commit
+TARGET_COMMIT=`git rev-parse --verify $TARGET`
+if [ $? != 0 ]; then
+  echo "Invalid target: $TARGET"
+  echo ''
+  cat ./scripts/help-text/release.txt
+  exit 2
 fi
 
-INCONSISTENT="`git diff origin/master || echo FAIL`"
-if test -n "$INCONSISTENT"
-then
-    echo "origin/master and current branch are inconsistent." 2>&1
-    echo "Use git diff origin/master to see changes." 2>&1
-    echo "Rebase or push, as appropriate, and run this command again." 2>&1
-    exit 1
+# Ensure that the target commit is an ancestor of master
+git merge-base --is-ancestor $TARGET_COMMIT master
+if [ $? != 0 ]; then
+  echo "Invalid target: $TARGET"
+  echo 'Please select a target commit which is an ancestor of master.'
+  exit 1
 fi
 
-CHANGELOG=`grep v$VERSION CHANGELOG`
-if test $? -ne 0
-then
-    echo "No entry in the CHANGELOG for version $VERSION." 2>&1
-    echo "To get a list of changes, use git log previous_tag.." 2>&1
-    echo "Add an entry to the CHANGELOG and run this command again." 2>&1
-    exit 1
+# Determine version to be released
+VERSION=`awk 'BEGIN { FS = "=" }; $1 == "version" { print $2 }' $PROPERTIES_FILE | awk '{ print $1 }'`
+if [ -z "$VERSION" ]; then
+  echo "Could not read the version from $PROPERTIES_FILE, please fix it and try again."
+  exit 1
 fi
 
-ant clean build test dist && \
-git tag v$VERSION && \
-git push origin v$VERSION && \
-echo "Publish completed successfully"
+# Ensure that release tag name wouldn't conflict with a local branch
+TAG_NAME="v$VERSION"
+git show-ref --verify refs/heads/$TAG_NAME >/dev/null 2>&1
+if [ $? = 0 ]; then
+  echo "Cannot create tag $TAG_NAME, as it would conflict with a local branch of the same name."
+  echo 'Please delete this branch and avoid naming branches like this in the future.'
+  echo "Hint: 'git branch -D $TAG_NAME' (WARNING: you will lose all local changes on this branch)"
+  exit 1
+fi
+
+# Create release tag
+git tag -a $TAG_NAME $TARGET_COMMIT -m "$TAG_NAME"
+if [ $? != 0 ]; then
+  echo "Could not create tag $TAG_NAME"
+  exit 1
+else
+  echo "Created tag $TAG_NAME at commit $TARGET_COMMIT ($TARGET)"
+fi
+
+# Push release tag
+echo "Pushing tag $TAG_NAME..."
+git push $REMOTE $TAG_NAME
+
+if [ $? != 0 ]; then
+  echo 'Push failed, clearing tag from local repo...'
+  git tag -d $TAG_NAME
+  exit 1
+fi
+
+echo "Tag push complete. Please check the deployment status on GitHub."

--- a/scripts/travis/publish-tag.sh
+++ b/scripts/travis/publish-tag.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Ensure that this is being run by Travis
+if [ "$TRAVIS" != "true" ] || [ "$USER" != "travis" ]; then
+  echo "This script should only be run by Travis CI."
+  exit 2
+fi
+
+# Ensure that the tag is named properly as a semver tag
+if [[ ! "$TRAVIS_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Tag $TRAVIS_TAG is NOT a valid semver tag (vX.Y.Z), please delete this tag."
+  exit 1
+fi
+
+# Ensure that the script is being run from the root project directory
+PROPERTIES_FILE='gradle.properties'
+if [ ! -f "$PROPERTIES_FILE" ]; then
+  echo "Could not find $PROPERTIES_FILE, are you sure this is being run from the root project directory?"
+  echo "PWD: ${PWD}"
+  exit 1
+fi
+
+# Determine the version being published
+VERSION=$(awk 'BEGIN { FS = "=" }; $1 == "version" { print $2 }' $PROPERTIES_FILE | awk '{ print $1 }')
+if [ -z "$VERSION" ]; then
+  echo "Could not read the version from $PROPERTIES_FILE, please fix it and try again."
+  exit 1
+fi
+
+# Ensure the tag corresponds to the current version
+EXPECTED_TAG="v$VERSION"
+if [ "$TRAVIS_TAG" != "$EXPECTED_TAG" ]; then
+  echo "Attempting to publish ParSeq version $VERSION from tag $TRAVIS_TAG is illegal."
+  echo "Please delete this tag and publish instead from tag $EXPECTED_TAG"
+  exit 1
+fi
+
+# Ensure the commit environment variable exists
+if [ -z "$TRAVIS_COMMIT" ]; then
+  echo 'Cannot find environment variable named TRAVIS_COMMIT, did the Travis API change?'
+  exit 1
+fi
+
+# Ensure that the tag commit is an ancestor of master
+git merge-base --is-ancestor $TRAVIS_COMMIT master
+if [ $? -ne 0 ]; then
+  echo "Tag $TRAVIS_TAG is NOT an ancestor of master!"
+  echo 'Please delete this tag and instead create a tag off a master commit.'
+  exit 1
+fi
+
+# Build and publish to Bintray
+echo "All checks passed, attempting to publish ParSeq $VERSION to Bintray..."
+./gradlew -Prelease build -x test && ./gradlew -Prelease bintrayUpload
+
+if [ $? == 0 ]; then
+  echo "Successfully published ParSeq $VERSION to Bintray."
+else
+  exit 1
+fi

--- a/subprojects/parseq-benchmark/build.gradle
+++ b/subprojects/parseq-benchmark/build.gradle
@@ -16,7 +16,6 @@ task fatJar(type: Jar) {
   manifest {
     attributes("Created-By": "Gradle",
         "Version": version,
-        "Built-By": project.rootProject.ext.builtByUser,
         "Build-JDK": JavaVersion.current())
     attributes 'Main-Class': 'com.linkedin.parseq.PerfLarge'
   }

--- a/subprojects/parseq-tracevis-server/build.gradle
+++ b/subprojects/parseq-tracevis-server/build.gradle
@@ -37,7 +37,6 @@ task fatJar(type: Jar, dependsOn: ':parseq-tracevis:makeDist') {
   manifest {
     attributes("Created-By": "Gradle",
         "Version": version,
-        "Built-By": project.rootProject.ext.builtByUser,
         "Build-JDK": JavaVersion.current())
     attributes 'Main-Class': 'com.linkedin.parseq.TracevisServerJarMain'
   }


### PR DESCRIPTION
Sets up automatic Bintray publications in Travis whenever a tag is pushed. Improves the `local-release` script and re-purposes the `release` script to create and push a tag to trigger a deployment. Also removes the "Built-By" property from the JAR manifest.

**Release Workflow:**
1. `./scripts/release` to release from the current HEAD.
2. Go to ParSeq on GitHub to verify that the publication job ran successfully.

**Snapshot Workflow:**
- `./scripts/local-release` to publish `x.y.z` to `~/local-repo`
- `./scripts/local-release -s` to publish `x.y.z-SNAPSHOT` to `~/local-repo`

**Note:**
- I did some mocked testing of the `publish-tag.sh` Travis script, but I can't do an end-to-end test until this is merged.
- Both scripts (`release` and `local-release`) support the `-h, --help` argument, so they should be pretty user friendly.

**Follow-up Items:**
- Document how to perform a hotfix release.
- See how email notifications work, address any issues.