### PR TITLE
Fetch master in the Travis publish-tag script

### DIFF
--- a/scripts/travis/publish-tag.sh
+++ b/scripts/travis/publish-tag.sh
@@ -42,6 +42,7 @@ if [ -z "$TRAVIS_COMMIT" ]; then
 fi
 
 # Ensure that the tag commit is an ancestor of master
+git fetch origin master:master
 git merge-base --is-ancestor $TRAVIS_COMMIT master
 if [ $? -ne 0 ]; then
   echo "Tag $TRAVIS_TAG is NOT an ancestor of master!"


### PR DESCRIPTION
Iterative fix for the Travis release automation. Since Travis checks out the repo from the release tag, we need to fetch master in order to determine if the release tag is an ancestor of master.