### PR TITLE
Build non-snapshot artifacts in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ dist: trusty
 install: true
 
 # Build and test commits to master, PRs to master, and release tags
-script: ./gradlew build
+script: ./gradlew -Prelease build
 branches:
   only:
   - master


### PR DESCRIPTION
Iterative fix for the Travis release automation. The Bintray upload failed because the build step was building snapshot artifacts, whereas the upload task was looking for release artifats. This should correct that.