### PR TITLE
Wrapping Client request in try catch to propagate failure to Task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
-v4.1.4
+v4.1.5
 ------
+
+v4.1.4
+------  
+
+* Catching exceptions thrown by Rest.li client impl and failing the Task.
 
 v4.1.3
 ------

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=4.1.3
+version=4.1.4
 group=com.linkedin.parseq
 org.gradle.parallel=true

--- a/subprojects/parseq-restli-client/src/main/java/com/linkedin/restli/client/ParSeqRestClient.java
+++ b/subprojects/parseq-restli-client/src/main/java/com/linkedin/restli/client/ParSeqRestClient.java
@@ -119,7 +119,11 @@ public class ParSeqRestClient extends BatchingStrategy<RequestGroup, RestRequest
   @Deprecated
   public <T> Promise<Response<T>> sendRequest(final Request<T> request, final RequestContext requestContext) {
     final SettablePromise<Response<T>> promise = Promises.settable();
-    _client.sendRequest(request, requestContext, new PromiseCallbackAdapter<T>(promise));
+    try {
+      _client.sendRequest(request, requestContext, new PromiseCallbackAdapter<T>(promise));
+    } catch (Throwable e) {
+      promise.fail(e);
+    }
     return promise;
   }
 

--- a/subprojects/parseq-restli-client/src/test/java/com/linkedin/restli/client/TestParSeqRestClientClientException.java
+++ b/subprojects/parseq-restli-client/src/test/java/com/linkedin/restli/client/TestParSeqRestClientClientException.java
@@ -1,0 +1,128 @@
+package com.linkedin.restli.client;
+
+import com.linkedin.common.callback.Callback;
+import com.linkedin.common.util.None;
+import com.linkedin.parseq.Task;
+import com.linkedin.r2.message.RequestContext;
+import com.linkedin.restli.client.multiplexer.MultiplexedRequest;
+import com.linkedin.restli.client.multiplexer.MultiplexedResponse;
+import org.testng.annotations.Test;
+
+
+public class TestParSeqRestClientClientException extends ParSeqRestClientIntegrationTest {
+
+  @Test
+  public void testExceptionNotThrownInClosureAndCausesTaskFailure() {
+    Task<?> task = greetingGet(1L);
+
+    runAndWaitException(task, ClientException.class);
+  }
+
+  @Override
+  protected ParSeqRestliClientConfig getParSeqRestClientConfig() {
+    return new ParSeqRestliClientConfigBuilder().build();
+  }
+
+  @Override
+  protected void customizeParSeqRestliClient(ParSeqRestliClientBuilder parSeqRestliClientBuilder) {
+    parSeqRestliClientBuilder.setClient(new ExceptionClient());
+  }
+
+  private static class ExceptionClient implements Client {
+    private ExceptionClient() {
+
+    }
+
+    @Override
+    public void shutdown(Callback<None> callback) {
+
+    }
+
+    @Override
+    public <T> ResponseFuture<T> sendRequest(Request<T> request, RequestContext requestContext) {
+      return null;
+    }
+
+    @Override
+    public <T> ResponseFuture<T> sendRequest(Request<T> request, RequestContext requestContext,
+        ErrorHandlingBehavior errorHandlingBehavior) {
+      return null;
+    }
+
+    @Override
+    public <T> ResponseFuture<T> sendRequest(RequestBuilder<? extends Request<T>> requestBuilder,
+        RequestContext requestContext) {
+      return null;
+    }
+
+    @Override
+    public <T> ResponseFuture<T> sendRequest(RequestBuilder<? extends Request<T>> requestBuilder,
+        RequestContext requestContext, ErrorHandlingBehavior errorHandlingBehavior) {
+      return null;
+    }
+
+    @Override
+    public <T> void sendRequest(Request<T> request, RequestContext requestContext, Callback<Response<T>> callback) {
+      throw new ClientException();
+    }
+
+    @Override
+    public <T> void sendRequest(RequestBuilder<? extends Request<T>> requestBuilder, RequestContext requestContext,
+        Callback<Response<T>> callback) {
+
+    }
+
+    @Override
+    public <T> ResponseFuture<T> sendRequest(Request<T> request) {
+      return null;
+    }
+
+    @Override
+    public <T> ResponseFuture<T> sendRequest(Request<T> request, ErrorHandlingBehavior errorHandlingBehavior) {
+      return null;
+    }
+
+    @Override
+    public <T> ResponseFuture<T> sendRequest(RequestBuilder<? extends Request<T>> requestBuilder) {
+      return null;
+    }
+
+    @Override
+    public <T> ResponseFuture<T> sendRequest(RequestBuilder<? extends Request<T>> requestBuilder,
+        ErrorHandlingBehavior errorHandlingBehavior) {
+      return null;
+    }
+
+    @Override
+    public <T> void sendRequest(Request<T> request, Callback<Response<T>> callback) {
+
+    }
+
+    @Override
+    public <T> void sendRequest(RequestBuilder<? extends Request<T>> requestBuilder, Callback<Response<T>> callback) {
+
+    }
+
+    @Override
+    public void sendRequest(MultiplexedRequest multiplexedRequest) {
+
+    }
+
+    @Override
+    public void sendRequest(MultiplexedRequest multiplexedRequest, Callback<MultiplexedResponse> callback) {
+
+    }
+
+    @Override
+    public void sendRequest(MultiplexedRequest multiplexedRequest, RequestContext requestContext,
+        Callback<MultiplexedResponse> callback) {
+
+    }
+  }
+
+  private static class ClientException extends RuntimeException {
+    ClientException() {
+      super("Exception thrown by client.");
+    }
+  }
+}


### PR DESCRIPTION
Currently, if the Client implementation throws an uncaught exception, the callback isn't executed. This is to ensure the Task is always failed if the Client implementation throws an exception.