### PR TITLE
Introduce Task::fromTry factory method

### DIFF
--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/Task.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/Task.java
@@ -1241,6 +1241,24 @@ public interface Task<T> extends Promise<T>, Cancellable {
   }
 
   /**
+   * Creates a new task from a {@code Try}, mapping its success and failure
+   * semantics accordingly.
+   * 
+   * If the {@code Try} is successful then the resulting task will contain the
+   * value. If the {@code Try} is a failure then the resulting task will also be
+   * failed and contain the {@code Throwable}.
+   */
+  public static <T> Task<T> fromTry(final Try<? extends T> tried) {
+    ArgumentUtil.requireNotNull(tried, "tried");
+
+    if (tried.isFailed()) {
+      return failure(tried.getError());
+    } else {
+      return value(tried.get());
+    }
+  }
+
+  /**
    * Creates a new task from a callable that returns a {@link Promise}.
    * This method is mainly used to integrate ParSeq with 3rd party
    * asynchronous libraries. It should not be used in order to compose

--- a/subprojects/parseq/src/test/java/com/linkedin/parseq/TestTasks.java
+++ b/subprojects/parseq/src/test/java/com/linkedin/parseq/TestTasks.java
@@ -36,6 +36,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import org.testng.annotations.Test;
 
+import com.linkedin.parseq.function.Failure;
+import com.linkedin.parseq.function.Success;
 import com.linkedin.parseq.promise.Promise;
 import com.linkedin.parseq.promise.PromiseListener;
 import com.linkedin.parseq.promise.Promises;
@@ -212,6 +214,20 @@ public class TestTasks extends BaseEngineTest {
       throw new RuntimeException();
     });
     runAndWaitException("testFromCompletionStageWithCallableException", task, RuntimeException.class);
+  }
+
+  @Test
+  public void testFromTryWithSuccess() {
+    String result = "FromTryWithSuccessResult";
+    Task<String> task = Task.fromTry(Success.of(result));
+    runAndWait("testFromTryWithSuccess", task);
+    assertEquals(result, task.get());
+  }
+
+  @Test
+  public void testFromTryWithFailure() {
+    Task<String> task = Task.fromTry(Failure.of(new RuntimeException()));
+    runAndWaitException("testFromTryWithFailure", task, RuntimeException.class);
   }
 
   @Test


### PR DESCRIPTION
This adds a `fromTry` static method to the `Task` class which captures the success and failure semantics of `Try` expressing them as a `Task`.

Closes #274 