### PR TITLE
Roll back Bintray upload on failure in Travis

### DIFF
--- a/scripts/travis/publish-tag.sh
+++ b/scripts/travis/publish-tag.sh
@@ -54,8 +54,22 @@ fi
 echo "All checks passed, attempting to publish ParSeq $VERSION to Bintray..."
 ./gradlew -Prelease bintrayUpload
 
-if [ $? == 0 ]; then
+if [ $? = 0 ]; then
   echo "Successfully published ParSeq $VERSION to Bintray."
 else
+  # Publish failed, so roll back the upload to ensure this version is completely wiped from the repo
+  echo "Publish failed, wiping $VERSION from Bintray..."
+  DELETE_VERSION_URL="https://api.bintray.com/packages/linkedin/maven/parseq/versions/${VERSION}"
+  curl -X DELETE --user ${BINTRAY_USER}:${BINTRAY_KEY} --fail $DELETE_VERSION_URL
+
+  if [ $? = 0 ]; then
+    echo "Successfully rolled $VERSION back."
+    echo 'Please retry the upload by restarting this Travis job.'
+  else
+    echo "Failed to roll back $VERSION, please manually delete this version from Bintray."
+    echo "See: https://bintray.com/linkedin/maven/parseq/$VERSION"
+    echo 'Once this version is deleted, please retry the upload by restarting this Travis job.'
+  fi
+
   exit 1
 fi


### PR DESCRIPTION
There exists a problem now where a Bintray upload can partially fail,
leaving the repo in a bad state where future uploads may fail due to
conflicts. This fix adjusts the Travis script so that a failed Bintray
upload will result in an API call to completely delete the version.

Same as the fix made in Rest.li: https://github.com/linkedin/rest.li/pull/318