### PR TITLE
Introduce parseq-all meta-project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
+v4.1.6
+------
+
 v4.1.5
 ------
+
+* Introduce `parseq-all` meta-project, which is useful for computing ParSeq's entire dependency tree.
 
 v4.1.4
 ------  

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=4.1.4
+version=4.1.5
 group=com.linkedin.parseq
 org.gradle.parallel=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ rootProject.name = 'parseq'
 
 def modules = [ /* the name of the modules to use */
     'parseq', // core parseq code
+    'parseq-all', // meta-project containing the entire dependency tree
     'parseq-batching',
     'parseq-benchmark',
     'parseq-examples',

--- a/subprojects/parseq-all/build.gradle
+++ b/subprojects/parseq-all/build.gradle
@@ -1,7 +1,7 @@
 /*
-    This is a meta-project that programmatically depends on all other consumer-facing modules
-    so that the entire dependency tree of parseq may be pulled in easily. Be warned that this
-    module is not intended to be directly consumed, since it'll bloat the consumer's dependencies.
+    This is a meta-project that programmatically depends on all other consumer-facing modules.
+    The purpose of this module is to act as an entry point for systems to compute the entire dependency tree of ParSeq.
+    It is not intended to be directly consumed like a normal module, since it'll bloat the consumer's dependencies.
  */
 ext {
     description = '''Meta-project containing the entire dependency tree of parseq; should not be consumed directly.'''

--- a/subprojects/parseq-all/build.gradle
+++ b/subprojects/parseq-all/build.gradle
@@ -1,0 +1,16 @@
+/*
+    This is a meta-project that programmatically depends on all other consumer-facing modules
+    so that the entire dependency tree of parseq may be pulled in easily. Be warned that this
+    module is not intended to be directly consumed, since it'll bloat the consumer's dependencies.
+ */
+ext {
+    description = '''Meta-project containing the entire dependency tree of parseq; should not be consumed directly.'''
+}
+
+dependencies {
+    rootProject.subprojects.forEach {
+        if (it != project && !it.name.endsWith('examples')) {
+            compile it
+        }
+    }
+}


### PR DESCRIPTION
Adds a new module, `parseq-all`, which is simply a meta-project that
programmatically depends on all other consumer-facing modules. This
makes it easier for certain use cases to pull in the entire dependency
tree.