### PR TITLE
updating javadoc for Task.par() solving #63

### DIFF
--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/Task.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/Task.java
@@ -1434,6 +1434,9 @@ public interface Task<T> extends Promise<T>, Cancellable {
    * will be resolved with results of all tasks as soon as all of them has
    * been completed successfully.
    *
+   * Tasks created using Task.blocking only run in parallel, tasks created using Task.callable are executed
+   * sequentially, although the visualization tools may show the task composition as parallel
+   *
    * <blockquote><pre>
    *  // this task will asynchronously fetch user and company in parallel
    *  // and create signature in a form {@code "<first name> <last name> working for <company>"}


### PR DESCRIPTION
#63 
Updating javadoc for Task.par() when parallel tasks are actually executed in parallel.
Current documentation is kind of misguiding, it should be clearly menntioned that Tasks composed using Task.callable will not be executed in parallel.