### PR TITLE
Update ASM to 7.0 for Java 11 compatibility

### DIFF
--- a/subprojects/parseq-lambda-names/build.gradle
+++ b/subprojects/parseq-lambda-names/build.gradle
@@ -14,6 +14,7 @@ dependencies {
   shadow group: 'org.ow2.asm', name: 'asm-tree', version: '7.0'
   shadow group: 'org.ow2.asm', name: 'asm', version: '7.0'
   shadow group: 'org.ow2.asm', name: 'asm-analysis', version: '7.0'
+  shadow group: 'net.bytebuddy', name: 'byte-buddy-dep', version: '1.9.16'
   testCompile group: 'org.testng', name: 'testng', version: '6.9.9'
 }
 
@@ -25,14 +26,24 @@ shadowJar {
   configurations += [project.configurations.shadow]
   classifier = null
   relocate 'org.objectweb', 'parseq.org.objectweb'
+  relocate 'net.bytebuddy', 'parseq.net.bytebuddy'
 }
 
 jar {
   finalizedBy shadowJar // The shadowJar task basically overwrites the output of the jar task (kind of hacky)
   manifest {
+    attributes 'Premain-Class': 'com.linkedin.parseq.lambda.ASMBasedTaskDescriptor$Agent'
     attributes 'Agent-Class': 'com.linkedin.parseq.lambda.ASMBasedTaskDescriptor$Agent'
+    attributes 'Can-Retransform-Classes': 'true'
   }
 }
 
+test {
+  dependsOn jar
+  if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
+    jvmArgs += ['-javaagent:' + jar.outputs.files.getSingleFile()]
+  }
+  classpath += jar.outputs.files
+}
 
 compileJava.options.compilerArgs += '-Xlint:-unchecked'

--- a/subprojects/parseq-lambda-names/build.gradle
+++ b/subprojects/parseq-lambda-names/build.gradle
@@ -11,13 +11,15 @@ configurations {
 
 dependencies {
   shadow group: 'com.linkedin.agentloader', name: 'linkedin-agent-loader', version: '1.0.4'
-  shadow group: 'org.ow2.asm', name: 'asm-all', version: '5.1'
+  shadow group: 'org.ow2.asm', name: 'asm-tree', version: '7.0'
+  shadow group: 'org.ow2.asm', name: 'asm', version: '7.0'
+  shadow group: 'org.ow2.asm', name: 'asm-analysis', version: '7.0'
   testCompile group: 'org.testng', name: 'testng', version: '6.9.9'
 }
 
 sourceSets.main.compileClasspath += configurations.shadow + sourceSets.main.compileClasspath
 
-javadoc.classpath += configurations.shadow + sourceSets.main.compileClasspath
+javadoc.classpath += sourceSets.main.compileClasspath
 
 shadowJar {
   configurations += [project.configurations.shadow]
@@ -25,10 +27,28 @@ shadowJar {
   relocate 'org.objectweb', 'parseq.org.objectweb'
 }
 
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 jar {
   finalizedBy shadowJar // The shadowJar task basically overwrites the output of the jar task (kind of hacky)
   manifest {
     attributes 'Agent-Class': 'com.linkedin.parseq.lambda.ASMBasedTaskDescriptor$Agent'
+  }
+}
+
+def classesOutput = classes.outputs.files
+
+test {
+  dependsOn jar
+  doFirst {
+    classpath += jar.outputs.files
+  }
+  useTestNG()
+  afterEvaluate {
+    classpath = classpath.filter { f -> !f.getPath().contains('/build/classes/java/main') }
   }
 }
 

--- a/subprojects/parseq-lambda-names/build.gradle
+++ b/subprojects/parseq-lambda-names/build.gradle
@@ -19,17 +19,12 @@ dependencies {
 
 sourceSets.main.compileClasspath += configurations.shadow + sourceSets.main.compileClasspath
 
-javadoc.classpath += sourceSets.main.compileClasspath
+javadoc.classpath += configurations.shadow + sourceSets.main.compileClasspath
 
 shadowJar {
   configurations += [project.configurations.shadow]
   classifier = null
   relocate 'org.objectweb', 'parseq.org.objectweb'
-}
-
-java {
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 jar {
@@ -39,17 +34,5 @@ jar {
   }
 }
 
-def classesOutput = classes.outputs.files
-
-test {
-  dependsOn jar
-  doFirst {
-    classpath += jar.outputs.files
-  }
-  useTestNG()
-  afterEvaluate {
-    classpath = classpath.filter { f -> !f.getPath().contains('/build/classes/java/main') }
-  }
-}
 
 compileJava.options.compilerArgs += '-Xlint:-unchecked'

--- a/subprojects/parseq-lambda-names/src/main/java/com/linkedin/parseq/lambda/LambdaClassLocator.java
+++ b/subprojects/parseq-lambda-names/src/main/java/com/linkedin/parseq/lambda/LambdaClassLocator.java
@@ -1,5 +1,6 @@
 package com.linkedin.parseq.lambda;
 
+import java.util.concurrent.ConcurrentMap;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
 
@@ -17,10 +18,12 @@ class LambdaClassLocator extends ClassVisitor {
   private InferredOperation _inferredOperation;
 
   private ClassLoader _loader;
+  private ConcurrentMap<String, String> _names;
 
-  LambdaClassLocator(int api, ClassLoader loader) {
+  LambdaClassLocator(int api, ClassLoader loader, ConcurrentMap<String, String> names) {
     super(api);
     _loader = loader;
+    _names = names;
   }
 
   @Override
@@ -61,5 +64,14 @@ class LambdaClassLocator extends ClassVisitor {
 
   LambdaClassDescription getLambdaClassDescription() {
     return new LambdaClassDescription(_className, _sourcePointer, _inferredOperation);
+  }
+
+  @Override
+  public void visitEnd() {
+    super.visitEnd();
+    if (isLambdaClass()) {
+      LambdaClassDescription lambdaClassDescription = getLambdaClassDescription();
+      _names.put(lambdaClassDescription.getClassName(), lambdaClassDescription.getDescription());
+    }
   }
 }

--- a/subprojects/parseq-lambda-names/test_supported_jvms
+++ b/subprojects/parseq-lambda-names/test_supported_jvms
@@ -8,5 +8,8 @@ while read jvm
 do
     echo "Testing with $jvm"
     setjdk $jvm
-    ../../gradlew clean test
+    ../../gradlew clean test --rerun-tasks --info
 done < supported_jvms
+
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk11.0.7-zulu.jdk/Contents/Home/
+../../gradlew clean test --info --rerun-tasks

--- a/subprojects/parseq-lambda-names/test_supported_jvms
+++ b/subprojects/parseq-lambda-names/test_supported_jvms
@@ -8,5 +8,5 @@ while read jvm
 do
     echo "Testing with $jvm"
     setjdk $jvm
-    mvn clean test
+    ../../gradlew clean test
 done < supported_jvms


### PR DESCRIPTION
Updating ASM for Java 11 compatibility in parseq-lambda-names. The older version of ASM cannot parse Java 11 bytecode so it will fail.