### PR TITLE
Implement scheduleToRun method in Task interface

### DIFF
--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/BaseTask.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/BaseTask.java
@@ -582,6 +582,11 @@ public abstract class BaseTask<T> extends DelegatingPromise<T>implements Task<T>
     }
 
     @Override
+    public void scheduleAndRun(Task<?>... tasks) {
+      _context.scheduleAndRun(tasks);
+    }
+
+    @Override
     public void run(final Task<?>... tasks) {
       _context.run(tasks);
       for (Task<?> task : tasks) {

--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/BaseTask.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/BaseTask.java
@@ -582,8 +582,8 @@ public abstract class BaseTask<T> extends DelegatingPromise<T>implements Task<T>
     }
 
     @Override
-    public void scheduleAndRun(Task<?>... tasks) {
-      _context.scheduleAndRun(tasks);
+    public void scheduleToRun(Task<?>... tasks) {
+      _context.scheduleToRun(tasks);
     }
 
     @Override

--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/Cancellable.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/Cancellable.java
@@ -22,6 +22,7 @@ package com.linkedin.parseq;
  * @author Chris Pettitt (cpettitt@linkedin.com)
  */
 public interface Cancellable {
+
   /**
    * Attempts to cancel the object with the given reason. Check the return
    * value to determine if cancellation was successful. Subsequent calls to

--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/Context.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/Context.java
@@ -54,6 +54,13 @@ public interface Context {
    */
   void run(Task<?>... tasks);
 
+  /**
+   * Schedule the tasks so they are queued for future async execution
+   *
+   * @param tasks the tasks to be scheduled asynchronously
+   */
+  void scheduleAndRun(Task<?>... tasks);
+
   void runSideEffect(Task<?>... tasks);
 
   /**

--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/Context.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/Context.java
@@ -57,9 +57,9 @@ public interface Context {
   /**
    * Schedule the tasks so they are queued for future async execution
    *
-   * @param tasks the tasks to be scheduled asynchronously
+   * @param tasks the tasks to be scheduled and run asynchronously
    */
-  void scheduleAndRun(Task<?>... tasks);
+  void scheduleToRun(Task<?>... tasks);
 
   void runSideEffect(Task<?>... tasks);
 

--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/FusionTask.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/FusionTask.java
@@ -338,7 +338,9 @@ class FusionTask<S, T> extends BaseTask<T> {
       /* There is no async predecessor, run propagation immediately */
       FusionTraceContext traceContext = new FusionTraceContext(context,
           FusionTask.this.getShallowTraceBuilder(), baseName);
+      setThreadLocalContext(context);
       propagate(traceContext, result);
+      removeThreadLocalContext();
     } else {
       /* There is async predecessor, need to run it first
          PropagationTask will actually run propagation */

--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/Task.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/Task.java
@@ -167,13 +167,14 @@ public interface Task<T> extends Promise<T>, Cancellable {
    *   to any plans, and it will throws {@link UnsupportedOperationException}
    *
    * Note: the task scheduled by {@link#scheduleToRun} would be running as a sibling task of the
-   *  enclosing task. In above example, the "Logging" Task was triggered as if triggered by
+   *  task created by the enclosing lambda function.
+   *  In above example, the "Logging" Task was triggered as if triggered by
    *  "fetchUrl" task.
    *
    *
    * @throws UnsupportedOperationException
    */
-  default void scheduleToRun() throws UnsupportedOperationException {
+  default Task<?> scheduleToRun() throws UnsupportedOperationException {
     Context ctx = _executionContext.get();
 
     if (ctx == null) {
@@ -181,6 +182,7 @@ public interface Task<T> extends Promise<T>, Cancellable {
     }
 
     ctx.scheduleToRun(this);
+    return this;
   }
 
   /**
@@ -192,15 +194,16 @@ public interface Task<T> extends Promise<T>, Cancellable {
    *
    * @param engine the engine to run this task in case no running context found
    */
-  default void scheduleOrEngineRun(Engine engine) {
+  default Task<?> scheduleOrEngineRun(Engine engine) {
     Context ctx = _executionContext.get();
 
     if (ctx == null) {
       engine.run(this);
-      return;
+      return this;
     }
 
     ctx.scheduleToRun(this);
+    return this;
   }
 
   /**

--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/internal/ContextImpl.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/internal/ContextImpl.java
@@ -121,6 +121,35 @@ public class ContextImpl implements Context, Cancellable {
     }
   }
 
+  private void submitTaskToExecutor(Task<?> task) {
+    _planContext.submitToPlanAsync(new PrioritizableRunnable() {
+      @Override
+      public void run() {
+//        _inTask.set(_task);
+        try {
+          task.contextRun(ContextImpl.this, _parent, _predecessorTasks);
+        } finally {
+//          _inTask.remove();
+        }
+      }
+
+      @Override
+      public int getPriority() {
+        return _task.getPriority();
+      }
+    });
+
+  }
+
+  @Override
+  public void scheduleAndRun(Task<?>... tasks) {
+    // TODO: how to deal with inTask?
+    // TODO: how to deal with Cancellation?
+    for (final Task<?> task: tasks) {
+      submitTaskToExecutor(task);
+    }
+  }
+
   @Override
   public void runSideEffect(final Task<?>... tasks) {
     checkInTask();

--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/internal/ContextImpl.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/internal/ContextImpl.java
@@ -120,21 +120,15 @@ public class ContextImpl implements Context, Cancellable {
     }
   }
 
-  /**
-   * This method submits the given task to the running queue and return.
-   * The tasks will be executed asynchronously.
-   *
-   * @param task the task to be submitted
-   */
-  public void submitToExecutorAsync(Task<?> task) {
+  private void submitToExecutorAsync(Task<?> task) {
     // Spawn a subContext to drive the running of submitted task later
     final ContextImpl subContext = new ContextImpl(_planContext, task, _parent, _predecessorTasks);
     // Note:
     // (1) We allow task async submission even current task is considered done(promise resolved),
-    //  so no Early Finish check during submission.
+    //  so no Early-Finish check during submission.
 
     // (2) Also since we don't assume when the async-submitted task will be run
-    // which means it could run even after the task which initiated it was resolved.
+    // which means it could run even after the task that initiated this was resolved.
     // Therefore we also do not add to _cancellable so it won't get cancelled if the task initiates it got resolved
       _planContext.submitToPlanAsync(new PrioritizableRunnable() {
         @Override
@@ -148,6 +142,12 @@ public class ContextImpl implements Context, Cancellable {
       });
   }
 
+  /**
+   * This method submits the given task to the running queue and return.
+   * The tasks will be executed asynchronously.
+   *
+   * @param tasks the tasks that to be submitted
+   */
   public void scheduleToRun(Task<?>... tasks) {
     for (final Task<?> task: tasks) {
       submitToExecutorAsync(task);

--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/internal/PlanContext.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/internal/PlanContext.java
@@ -107,6 +107,10 @@ public class PlanContext {
     _taskExecutor.execute(runnable);
   }
 
+  public void submitToPlanAsync(PrioritizableRunnable runnable) {
+    _taskExecutor.submitToQueue(runnable);
+  }
+
   public Cancellable schedule(long time, TimeUnit unit, Runnable runnable) {
     return _timerScheduler.schedule(time, unit, runnable);
   }

--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/internal/SerialExecutor.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/internal/SerialExecutor.java
@@ -104,6 +104,11 @@ public class SerialExecutor {
     }
   }
 
+  public void submitToQueue(final PrioritizableRunnable runnable) {
+    _queue.add(runnable);
+    _pendingCount.incrementAndGet();
+  }
+
   /*
    * This method acts as a happen-before relation between current thread and next Runnable that will
    * be executed by this executor because of properties of underlying _executor.execute().

--- a/subprojects/parseq/src/test/java/com/linkedin/parseq/TestTaskStates.java
+++ b/subprojects/parseq/src/test/java/com/linkedin/parseq/TestTaskStates.java
@@ -362,7 +362,7 @@ public class TestTaskStates {
     }
 
     @Override
-    public void scheduleAndRun(Task<?>... tasks) {
+    public void scheduleToRun(Task<?>... tasks) {
         throw new UnsupportedOperationException();
     }
 

--- a/subprojects/parseq/src/test/java/com/linkedin/parseq/TestTaskStates.java
+++ b/subprojects/parseq/src/test/java/com/linkedin/parseq/TestTaskStates.java
@@ -362,6 +362,11 @@ public class TestTaskStates {
     }
 
     @Override
+    public void scheduleAndRun(Task<?>... tasks) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public After after(final Promise<?>... promises) {
       throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
Implement scheduleToRun method in Task interface so the task can be scheduled to current running plan and will be executed asynchronously.

The scheduled task will be run as sibling task.

Example:
```java
    Task.async("MainAsyncTask", () -> {
      final SettablePromise<String> result = Promises.settable();

      System.out.println("I am the MainAsyncTask");

      Task.callable("callable inside", () -> {
        System.out.println("I am a sibling task to MainAsyncTask");
        return "irrelevant";
      }).scheduleToRun();

      result.done("Value");
      return result;
    }).andThen("AndThenAction", 
            Task.action("theActionTask", () -> System.out.println("follow up on Main task")) 
    ).scheduleOrEngineRun(engine);
```
![Screen Shot 2021-01-28 at 12 53 32 AM](https://user-images.githubusercontent.com/52180478/106115917-26961480-6106-11eb-9954-13e24c553807.png)
