### PR TITLE
Rename Task.blocking to Task.runInExecutor

### DIFF
--- a/subprojects/parseq-batching/src/test/java/com/linkedin/parseq/batching/TestTaskSimpleBatchingStrategyBlocking.java
+++ b/subprojects/parseq-batching/src/test/java/com/linkedin/parseq/batching/TestTaskSimpleBatchingStrategyBlocking.java
@@ -36,7 +36,7 @@ public class TestTaskSimpleBatchingStrategyBlocking extends BaseEngineTest {
 
     @Override
     public Task<Map<Integer, Try<String>>> taskForBatch(Set<Integer> keys) {
-      return Task.blocking(() -> {
+      return Task.runInExecutor(() -> {
         try {
           // make this batching task long-running
           Thread.sleep(_sleepMs);

--- a/subprojects/parseq-zk-client/src/main/java/com/linkedin/parseq/zk/client/ZKClientImpl.java
+++ b/subprojects/parseq-zk-client/src/main/java/com/linkedin/parseq/zk/client/ZKClientImpl.java
@@ -18,14 +18,12 @@ package com.linkedin.parseq.zk.client;
 
 import com.linkedin.parseq.Context;
 import com.linkedin.parseq.Engine;
-import com.linkedin.parseq.MultiException;
 import com.linkedin.parseq.Task;
 import com.linkedin.parseq.promise.Promise;
 import com.linkedin.parseq.promise.PromiseListener;
 import com.linkedin.parseq.promise.Promises;
 import com.linkedin.parseq.promise.SettablePromise;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -282,7 +280,7 @@ class ZKClientImpl implements ZKClient {
    */
   @Override
   public Task<List<OpResult>> multi(List<Op> ops, Executor executor) {
-    return Task.blocking(() -> _zkClient.multi(ops), executor);
+    return Task.runInExecutor(() -> _zkClient.multi(ops), executor);
   }
 
   /**

--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/AsyncCallableTask.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/AsyncCallableTask.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.parseq;
 
-import com.linkedin.parseq.EngineBuilder;
 import com.linkedin.parseq.internal.ArgumentUtil;
 import com.linkedin.parseq.promise.Promise;
 import com.linkedin.parseq.promise.Promises;
@@ -37,7 +36,7 @@ import java.util.concurrent.Executor;
  * To use this class with an engine, register an executor with engine using
  * {@link #register(EngineBuilder, java.util.concurrent.Executor)}
  *
- * @deprecated  As of 2.0.0, replaced by {@link Task#blocking(String, Callable, Executor) Task.blocking}.
+ * @deprecated  As of 2.0.0, replaced by {@link Task#runInExecutor(String, Callable, Executor) Task.blocking}.
  * @author Walter Fender (wfender@linkedin.com)
  */
 @Deprecated
@@ -51,7 +50,7 @@ public class AsyncCallableTask<R> extends BaseTask<R> {
   }
 
   /**
-   * @deprecated  As of 2.0.0, replaced by {@link Task#blocking(String, Callable, Executor) Task.blocking}.
+   * @deprecated  As of 2.0.0, replaced by {@link Task#runInExecutor(String, Callable, Executor) Task.blocking}.
    */
   @Deprecated
   public AsyncCallableTask(final Callable<R> syncJob) {
@@ -59,7 +58,7 @@ public class AsyncCallableTask<R> extends BaseTask<R> {
   }
 
   /**
-   * @deprecated  As of 2.0.0, replaced by {@link Task#blocking(String, Callable, Executor) Task.blocking}.
+   * @deprecated  As of 2.0.0, replaced by {@link Task#runInExecutor(String, Callable, Executor) Task.blocking}.
    */
   @Deprecated
   public AsyncCallableTask(final String name, final Callable<R> syncJob) {

--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/Task.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/Task.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -1079,7 +1078,7 @@ public interface Task<T> extends Promise<T>, Cancellable {
    * Creates a new task that have a value of type {@code Void}. Because the
    * returned task returns no value, it is typically used to produce side effects.
    * It is not appropriate for long running or blocking actions. If action is
-   * long running or blocking use {@link #blocking(String, Callable, Executor) blocking} method.
+   * long running or blocking use {@link #runInExecutor(String, Callable, Executor) blocking} method.
    *
    * <blockquote><pre>
    * // this task will print "Hello" on standard output
@@ -1167,7 +1166,7 @@ public interface Task<T> extends Promise<T>, Cancellable {
    * from the supplied callable. This task is useful when doing basic
    * computation that does not require asynchrony. It is not appropriate for
    * long running or blocking callables. If callable is long running or blocking
-   * use {@link #blocking(String, Callable, Executor) blocking} method.
+   * use {@link #runInExecutor(String, Callable, Executor) blocking} method.
    *
    * <blockquote><pre>
    * // this task will complete with {@code String} representing current time
@@ -1313,7 +1312,7 @@ public interface Task<T> extends Promise<T>, Cancellable {
    *
    * This method is not appropriate for long running or blocking callables.
    * If callable is long running or blocking use
-   * {@link #blocking(String, Callable, Executor) blocking} method.
+   * {@link #runInExecutor(String, Callable, Executor) blocking} method.
    * <p>
    *
    * @param <T> the type of the return value for this task
@@ -1403,7 +1402,7 @@ public interface Task<T> extends Promise<T>, Cancellable {
    * @return a new task that will submit the callable to given executor and complete
    * with result returned by that callable
    */
-  public static <T> Task<T> blocking(final String name, final Callable<? extends T> callable, final Executor executor) {
+  public static <T> Task<T> runInExecutor(final String name, final Callable<? extends T> callable, final Executor executor) {
     ArgumentUtil.requireNotNull(callable, "callable");
     ArgumentUtil.requireNotNull(callable, "executor");
     Task<T> blockingTask = async(name, () -> {
@@ -1422,12 +1421,24 @@ public interface Task<T> extends Promise<T>, Cancellable {
   }
 
   /**
-   * Equivalent to {@code blocking("blocking", callable, executor)}.
-   * @see #blocking(String, Callable, Executor)
+   * Equivalent to {@code runInExecutor("runInExecutor", callable, executor)}.
+   * @see #runInExecutor(String, Callable, Executor)
    */
-  public static <T> Task<T> blocking(final Callable<? extends T> callable, final Executor executor) {
-    return blocking("blocking: " + _taskDescriptor.getDescription(callable.getClass().getName()), callable, executor);
+  public static <T> Task<T> runInExecutor(final Callable<? extends T> callable, final Executor executor) {
+    return runInExecutor("runInExecutor: " + _taskDescriptor.getDescription(callable.getClass().getName()), callable, executor);
   }
+
+  @Deprecated
+  public static <T> Task<T> blocking(final Callable<? extends T> callable, final Executor executor) {
+    return runInExecutor("runInExecutor: " + _taskDescriptor.getDescription(callable.getClass().getName()), callable, executor);
+  }
+
+
+  @Deprecated
+  public static <T> Task<T> blocking(final String name, final Callable<? extends T> callable, final Executor executor) {
+    return runInExecutor(name, callable, executor);
+  }
+
 
   /**
    * Creates a new task that will run given tasks in parallel. Returned task

--- a/subprojects/parseq/src/test/java/com/linkedin/parseq/TestTaskFactoryMethods.java
+++ b/subprojects/parseq/src/test/java/com/linkedin/parseq/TestTaskFactoryMethods.java
@@ -94,7 +94,7 @@ public class TestTaskFactoryMethods extends BaseEngineTest {
   public void testBlocking() {
     TestingExecutorService es = new TestingExecutorService(Executors.newSingleThreadExecutor());
     try {
-      Task<String> task = Task.blocking(() -> "from blocking", es);
+      Task<String> task = Task.runInExecutor(() -> "from blocking", es);
       runAndWait("TestTaskFactoryMethods.testBlocking", task);
       assertEquals(task.get(), "from blocking");
       assertEquals(es.getCount(), 1);

--- a/subprojects/parseq/src/test/java/com/linkedin/parseq/TestTaskType.java
+++ b/subprojects/parseq/src/test/java/com/linkedin/parseq/TestTaskType.java
@@ -28,7 +28,7 @@ public class TestTaskType extends TestTask {
   public void testBlockingTaskType() {
     TestingExecutorService es = new TestingExecutorService(Executors.newSingleThreadExecutor());
     try {
-      Task<String> task = Task.blocking(() -> "blocking task", es);
+      Task<String> task = Task.runInExecutor(() -> "blocking task", es);
       runAndWait("blockingTaskType", task);
       assertEquals(task.getShallowTrace().getTaskType(), TaskType.BLOCKING.getName());
     } finally {


### PR DESCRIPTION
ParSeq beginner users are often confused about the name of "Task.blocking". It is even more confusing if comparing with other two Task.callable, Task.async, Task.action, Task.value.
(I personally think Task.async confusing as well..)

By analogy, Task.callable means to create a task with a callable. Task.value means to create a task with a value. I think `Task.runInExecutor` is a better user-facing name.  It means to create a task that would "run in executor".
