### PR TITLE
Adding Task.recover(String, Class<X extends Throwable>, func) method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 v5.1.3
 ------
-* Fix for multiple javadoc warnings coming from Task.java 
-
+* Fix for multiple javadoc warnings coming from Task.java
+* Add recover() method with exception filter
+ 
 v5.1.2
 ------
 - Migrate the ParSeq release process from Bintray to JFrog Artifactory.

--- a/subprojects/parseq/src/test/java/com/linkedin/parseq/TestFusionTask.java
+++ b/subprojects/parseq/src/test/java/com/linkedin/parseq/TestFusionTask.java
@@ -66,6 +66,11 @@ public class TestFusionTask extends AbstractTaskTest {
   }
 
   @Test
+  public void testRecoverWithExceptionFilter() {
+    testRecoverWithExceptionFilter(4);
+  }
+
+  @Test
   public void testCancelledRecover() {
     testCancelledRecover(4);
   }

--- a/subprojects/parseq/src/test/java/com/linkedin/parseq/TestTask.java
+++ b/subprojects/parseq/src/test/java/com/linkedin/parseq/TestTask.java
@@ -55,6 +55,11 @@ public class TestTask extends AbstractTaskTest {
   }
 
   @Test
+  public void testRecoverWithExceptionFilter() {
+    testRecoverWithExceptionFilter(5);
+  }
+
+  @Test
   public void testCancelledRecover() {
     testCancelledRecover(5);
   }


### PR DESCRIPTION
From my experience, it's a repeating pattern to provide different recovery for different types of failures. Currently, it looks like this:
```
Task<Response> task = createResponseTask().recover(ex -> {
                                           if (failure instanceof BadRequestException) {
                                                    return new Response(HTTP_400, ex.getMessage());
                                           }
                                           else if (failure instanceof AuthException) {
                                                    return new Response(HTTP_403, ex.getMessage());
                                           }
                                           else if (failure instanceof ServiceException) {
                                                    return new Response(HTTP_500, ex.getMessage());
                                           });
```

With this introduction of 'recover with failure filter' this same code would get shorter and more concise:

```
Task<Response> task = createResponseTask()
                        .recover(BadRequestException.class, ex -> new Response(HTTP_400, ex.getMessage()))
                        .recover(AuthException.class, ex -> new Response(HTTP_403, ex.getMessage());
                        .recover(ServiceException.class, ex -> new Response(HTTP_500, ex.getMessage());
```