### PR TITLE
Add stack trace in error message when starting TracevisServer

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=5.1.2
+version=5.1.3
 group=com.linkedin.parseq
 org.gradle.parallel=true

--- a/subprojects/parseq-tracevis-server/src/main/java/com/linkedin/parseq/TracevisServerJarMain.java
+++ b/subprojects/parseq-tracevis-server/src/main/java/com/linkedin/parseq/TracevisServerJarMain.java
@@ -72,8 +72,8 @@ public class TracevisServerJarMain {
 
           new TracevisHttpsServer(dotLocation, httpPort, base, base, Constants.DEFAULT_CACHE_SIZE, Constants.DEFAULT_TIMEOUT_MS, sslPort,
               keyStorePath, keyStorePassword, trustStorePath, trustStorePassword).start();
-        } catch (IOException ex) {
-          throw new IOException("Failed to find config profiles " + args[1] + "!");
+        } catch (Exception ex) {
+            throw new IOException("Failed to find config profiles " + args[1] + "!", ex);
         }
       }
 


### PR DESCRIPTION
A minor fix for TracevisServer:
The stack trace was previously missing