### PR TITLE
To prevent ListenableFutureUtil throw PromiseAlreadyResolved exception, also added log to see why it happened

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ target
 .DS_Store
 .gradle
 /.gradle
+.settings
+subprojects/parseq-lambda-names/bin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v5.1.6
+------
+* To prevent ListenableFutureUtil throw PromiseAlreadyResolved exception, also added log to see why it happened
+
 v5.1.5
 ------
 * Add rate limit retry policy

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=5.1.5
+version=5.1.6
 group=com.linkedin.parseq
 org.gradle.parallel=true


### PR DESCRIPTION
This change is created out of an investigation for following stacktrace when ParSeq is used together with grpc-java

```
com.linkedin.parseq.promise.PromiseResolvedException: <LOG MESSAGE REDACTED DUE TO LINKEDIN'S PRIVACY POLICY>
	at com.linkedin.parseq.promise.SettablePromiseImpl.ensureNotDone(SettablePromiseImpl.java:156)
	at com.linkedin.parseq.promise.SettablePromiseImpl.finalizeResult(SettablePromiseImpl.java:124)
	at com.linkedin.parseq.promise.SettablePromiseImpl.doFinish(SettablePromiseImpl.java:116)
	at com.linkedin.parseq.promise.SettablePromiseImpl.fail(SettablePromiseImpl.java:56)
	at com.linkedin.parseq.BaseTask.fail(BaseTask.java:336)
	at com.linkedin.parseq.BaseTask.lambda$contextRun$0(BaseTask.java:207)
	at com.linkedin.parseq.promise.SettablePromiseImpl.notifyListener(SettablePromiseImpl.java:148)
	at com.linkedin.parseq.promise.SettablePromiseImpl.notifyListeners(SettablePromiseImpl.java:136)
	at com.linkedin.parseq.promise.SettablePromiseImpl.lambda$doFinish$0(SettablePromiseImpl.java:117)
	at com.linkedin.parseq.internal.Continuations.submit(Continuations.java:46)
	at com.linkedin.parseq.promise.SettablePromiseImpl.doFinish(SettablePromiseImpl.java:117)
	at com.linkedin.parseq.promise.SettablePromiseImpl.fail(SettablePromiseImpl.java:56)
	at com.linkedin.parseq.guava.ListenableFutureUtil.lambda$fromListenableFuture$0(ListenableFutureUtil.java:49)
	at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:30)
	at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1213)
	at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:983)
	at com.google.common.util.concurrent.AbstractFuture.setException(AbstractFuture.java:771)
	at io.grpc.stub.ClientCalls$GrpcFuture.setException(ClientCalls.java:563)
	at io.grpc.stub.ClientCalls$UnaryStreamToFuture.onClose(ClientCalls.java:533)
	at io.grpc.PartialForwardingClientCallListener.onClose(PartialForwardingClientCallListener.java:39)
	at io.grpc.ForwardingClientCallListener.onClose(ForwardingClientCallListener.java:23)
	at io.grpc.ForwardingClientCallListener$SimpleForwardingClientCallListener.onClose(ForwardingClientCallListener.java:40)
	at com.linkedin.grpc.interceptor.logging.ClientLogInterceptor$1$1.onClose(ClientLogInterceptor.java:50)
	at io.grpc.PartialForwardingClientCallListener.onClose(PartialForwardingClientCallListener.java:39)
	at io.grpc.ForwardingClientCallListener.onClose(ForwardingClientCallListener.java:23)
	at io.grpc.ForwardingClientCallListener$SimpleForwardingClientCallListener.onClose(ForwardingClientCallListener.java:40)
	at io.grpc.PartialForwardingClientCallListener.onClose(PartialForwardingClientCallListener.java:39)
	at io.grpc.ForwardingClientCallListener.onClose(ForwardingClientCallListener.java:23)
	at io.grpc.ForwardingClientCallListener$SimpleForwardingClientCallListener.onClose(ForwardingClientCallListener.java:40)
	at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:557)
	at io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:69)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:738)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:717)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

