### PR TITLE
Fix promiseAlreadyResolved exception thrown by ListenableFutureUtil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v5.1.7
+------
+* Change ListenableFutureUtil implementation to prevent promise being resolved more than once.
+
 v5.1.6
 ------
 * To prevent ListenableFutureUtil throw PromiseAlreadyResolved exception, also added log to see why it happened

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=5.1.6
+version=5.1.7
 group=com.linkedin.parseq
 org.gradle.parallel=true

--- a/subprojects/parseq-guava-interop/build.gradle
+++ b/subprojects/parseq-guava-interop/build.gradle
@@ -6,5 +6,6 @@ dependencies {
   compile project(":parseq")
   compile "com.google.guava:guava:30.1.1-jre"
 
+  testCompile project(':parseq-test-api')
   testCompile "org.testng:testng:6.9.9"
 }

--- a/subprojects/parseq-guava-interop/src/main/java/com/linkedin/parseq/guava/ListenableFutureUtil.java
+++ b/subprojects/parseq-guava-interop/src/main/java/com/linkedin/parseq/guava/ListenableFutureUtil.java
@@ -41,7 +41,7 @@ public class ListenableFutureUtil {
           }
         };
 
-    final SettablePromise<T> promise = task.getSettableDelegate();
+    final SettablePromise<T> promise = task.getSettablePromise();
 
     // Setup forward event propagation ListenableFuture -> Task.
     Runnable callbackRunnable = () -> {
@@ -145,9 +145,8 @@ public class ListenableFutureUtil {
       return _promise;
     }
 
-    @Override
-    public SettablePromise<T> getSettableDelegate() {
-      return super.getSettableDelegate();
+    public SettablePromise<T> getSettablePromise() {
+      return _promise;
     }
   }
 }

--- a/subprojects/parseq-guava-interop/src/main/java/com/linkedin/parseq/guava/ListenableFutureUtil.java
+++ b/subprojects/parseq-guava-interop/src/main/java/com/linkedin/parseq/guava/ListenableFutureUtil.java
@@ -1,6 +1,7 @@
 package com.linkedin.parseq.guava;
 
 import com.linkedin.parseq.promise.Promises;
+import java.util.Collection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
@@ -29,7 +30,10 @@ public class ListenableFutureUtil {
 
   public static <T> Task<T> fromListenableFuture(ListenableFuture<T> future) {
 
-    // BaseTask's promise will be listening to this
+    /**
+     * BaseTask's promise will be listening to this
+     * also see {@link BaseTask#contextRun(Context, Task, Collection)}
+     */
     final SettablePromise<T> promise = Promises.settable();
 
     // Setup cancellation propagation from Task -> ListenableFuture.

--- a/subprojects/parseq-guava-interop/src/main/java/com/linkedin/parseq/guava/ListenableFutureUtil.java
+++ b/subprojects/parseq-guava-interop/src/main/java/com/linkedin/parseq/guava/ListenableFutureUtil.java
@@ -1,5 +1,6 @@
 package com.linkedin.parseq.guava;
 
+import com.linkedin.parseq.promise.Promises;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
@@ -133,6 +134,7 @@ public class ListenableFutureUtil {
    */
   @VisibleForTesting
   static class SettableTask<T> extends BaseTask<T> {
+    private final SettablePromise _promise = Promises.settable();
 
     public SettableTask(String name) {
       super(name);
@@ -140,7 +142,7 @@ public class ListenableFutureUtil {
 
     @Override
     protected Promise<? extends T> run(Context context) throws Throwable {
-      return getDelegate();
+      return _promise;
     }
 
     @Override

--- a/subprojects/parseq-guava-interop/src/test/java/com/linkedin/parseq/guava/ListenableFutureUtilTest.java
+++ b/subprojects/parseq-guava-interop/src/test/java/com/linkedin/parseq/guava/ListenableFutureUtilTest.java
@@ -5,6 +5,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.linkedin.parseq.Task;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -16,7 +17,7 @@ public class ListenableFutureUtilTest extends BaseEngineTest {
 
   private void runUntilComplete(Task task) throws Exception {
     this.getEngine().run(task);
-    task.await();
+    task.await(5, TimeUnit.SECONDS);
   }
 
   @Test
@@ -26,6 +27,7 @@ public class ListenableFutureUtilTest extends BaseEngineTest {
 
     // Test cancel propagation from Task to ListenableFuture
     task.cancel(new RuntimeException());
+    runUntilComplete(task);
     Assert.assertTrue(listenableFuture.isCancelled());
 
     listenableFuture = new ListenableFutureUtil.SettableFuture<>();


### PR DESCRIPTION
Based on following stack trace
```
2022/01/14 13:50:52.897 [[31merror[0m] [c.l.p.p.SettablePromiseImpl] [grpc-default-executor-461] [voyager-api-notifications] [] An exception was thrown by listener
com.linkedin.parseq.promise.PromiseResolvedException: Promise has already been satisfied
	at com.linkedin.parseq.promise.SettablePromiseImpl.ensureNotDone(SettablePromiseImpl.java:156)
	at com.linkedin.parseq.promise.SettablePromiseImpl.finalizeResult(SettablePromiseImpl.java:124)
	at com.linkedin.parseq.promise.SettablePromiseImpl.doFinish(SettablePromiseImpl.java:116)
	at com.linkedin.parseq.promise.SettablePromiseImpl.done(SettablePromiseImpl.java:51)
	at com.linkedin.parseq.BaseTask.done(BaseTask.java:322)
	at com.linkedin.parseq.BaseTask.lambda$contextRun$0(BaseTask.java:209)
	at com.linkedin.parseq.promise.SettablePromiseImpl.notifyListener(SettablePromiseImpl.java:148)
	at com.linkedin.parseq.promise.SettablePromiseImpl.notifyListeners(SettablePromiseImpl.java:136)
	at com.linkedin.parseq.promise.SettablePromiseImpl.lambda$doFinish$0(SettablePromiseImpl.java:117)
	at com.linkedin.parseq.internal.Continuations.submit(Continuations.java:46)
```

Suspect the exception to be thrown on following location
https://github.com/linkedin/parseq/blob/master/subprojects/parseq/src/main/java/com/linkedin/parseq/BaseTask.java#L200


Changes:

(1) Use a new Promise in SettableTask in ListenableFutureUtil
(2) Use engines.run in unit tests

