### PR TITLE
Mute an NPE thrown by parseq-lambda-names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 v5.1.6
 ------
 * To prevent ListenableFutureUtil throw PromiseAlreadyResolved exception, also added log to see why it happened
+* Mute some NPE thrown by parseq-lambda-names and print meaningful warning message
 
 v5.1.5
 ------

--- a/subprojects/parseq-lambda-names/src/main/java/com/linkedin/parseq/lambda/LambdaMethodVisitor.java
+++ b/subprojects/parseq-lambda-names/src/main/java/com/linkedin/parseq/lambda/LambdaMethodVisitor.java
@@ -53,6 +53,9 @@ class LambdaMethodVisitor extends MethodVisitor {
 
   @Override
   public void visitEnd() {
+    if (_lambdaSourcePointer == null) {
+      return;
+    }
     if (_containsSyntheticLambda) {
       String classToVisit = _methodInsnOwner.replace('/', '.');
       SyntheticLambdaAnalyzer syntheticLambdaAnalyzer = new SyntheticLambdaAnalyzer(api, classToVisit, _methodInsnName);

--- a/subprojects/parseq-lambda-names/src/main/java/com/linkedin/parseq/lambda/SourcePointer.java
+++ b/subprojects/parseq-lambda-names/src/main/java/com/linkedin/parseq/lambda/SourcePointer.java
@@ -17,10 +17,16 @@ class SourcePointer {
 
   /* package private */ static Optional<SourcePointer> get(Exception exception) {
     //create an exception, discard known elements from stack trace and find first element with suspect
-    return Arrays.stream(exception.getStackTrace())
+    Optional ret = Arrays.stream(exception.getStackTrace())
         .filter(SourcePointer::notLambdaStuff)
         .findFirst()
         .map(SourcePointer::sourcePointer);
+    if (!ret.isPresent()) {
+      System.out.println("WARNING： ParSeq cannot generate lambda function SourcePointer， "
+          + "source stacktrace will be printed:");
+      exception.printStackTrace();
+    }
+    return ret;
   }
 
   private static boolean notLambdaStuff(StackTraceElement element) {


### PR DESCRIPTION
Customer complains about NPE thrown and printed at 
https://github.com/linkedin/parseq/blob/master/subprojects/parseq-lambda-names/src/main/java/com/linkedin/parseq/lambda/ASMBasedTaskDescriptor.java#L219

Some of them were confused and thought they were actual errors.

The cause of these NPE are also not clear. Adding message can help us understand why it happens in some code.

Here mute the message and print more meaningful warning.