### PR TITLE
Use a pined jdk 8 version in github action,as a workaround for issue #318

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        java: [8]
+        java: [8.0.312+7]
     name: Java ${{ matrix.java }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8]
+        java: [8.0.312+7]
     name: Java ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
https://github.com/linkedin/parseq/issues/318