### PR TITLE
add more print information to instrument the occasional lambda name generation failure during boot time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v5.1.8
+------
+* Add more print information to instrument the occasional lambda name generation failure during boot time.
+
 v5.1.7
 ------
 * Change ListenableFutureUtil implementation to prevent promise being resolved more than once.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=5.1.7
+version=5.1.8
 group=com.linkedin.parseq
 org.gradle.parallel=true

--- a/subprojects/parseq-lambda-names/src/main/java/com/linkedin/parseq/lambda/ASMBasedTaskDescriptor.java
+++ b/subprojects/parseq-lambda-names/src/main/java/com/linkedin/parseq/lambda/ASMBasedTaskDescriptor.java
@@ -159,6 +159,8 @@ public class ASMBasedTaskDescriptor implements TaskDescriptor {
          */
         latch.await(1, TimeUnit.MINUTES);
       } catch (InterruptedException e) {
+        System.out.println("ERROR: ParSeq Latch timed out suggesting serious issue in ASMBasedTaskDescriptor. "
+            + "Current number of class being analyzed: " + String.valueOf(_count.get()));
         e.printStackTrace();
         Thread.currentThread().interrupt();
       }
@@ -216,6 +218,7 @@ public class ASMBasedTaskDescriptor implements TaskDescriptor {
              * We need to catch  everything because other
              * threads may be blocked on CountDownLatch.
              */
+            System.out.println("WARNING: Parseq cannot doAnalyze");
             t.printStackTrace();
           }
           if (_count.decrementAndGet() == 0) {
@@ -233,6 +236,9 @@ public class ASMBasedTaskDescriptor implements TaskDescriptor {
       if (cv.isLambdaClass()) {
         LambdaClassDescription lambdaClassDescription = cv.getLambdaClassDescription();
         add(lambdaClassDescription.getClassName(), lambdaClassDescription.getDescription());
+        System.out.println("ParSeq::INFO:: Processed lambda name for " +
+            lambdaClassDescription.getClassName() + " as " + lambdaClassDescription
+            .getDescription());
       }
     }
   }

--- a/subprojects/parseq-lambda-names/src/main/java/com/linkedin/parseq/lambda/ASMBasedTaskDescriptor.java
+++ b/subprojects/parseq-lambda-names/src/main/java/com/linkedin/parseq/lambda/ASMBasedTaskDescriptor.java
@@ -236,9 +236,6 @@ public class ASMBasedTaskDescriptor implements TaskDescriptor {
       if (cv.isLambdaClass()) {
         LambdaClassDescription lambdaClassDescription = cv.getLambdaClassDescription();
         add(lambdaClassDescription.getClassName(), lambdaClassDescription.getDescription());
-        System.out.println("ParSeq::INFO:: Processed lambda name for " +
-            lambdaClassDescription.getClassName() + " as " + lambdaClassDescription
-            .getDescription());
       }
     }
   }

--- a/subprojects/parseq-lambda-names/src/main/java/com/linkedin/parseq/lambda/LambdaClassLocator.java
+++ b/subprojects/parseq-lambda-names/src/main/java/com/linkedin/parseq/lambda/LambdaClassLocator.java
@@ -49,6 +49,9 @@ class LambdaClassLocator extends ClassVisitor {
       return mv;
     }
 
+    if (_sourcePointer == null) {
+      return mv;
+    }
     //parse generated lambda code to get details about operation
     return new LambdaMethodVisitor(api, mv, _sourcePointer, this::setInferredOperation, _loader);
   }


### PR DESCRIPTION
User reporting the threads hang when waiting for coundown latch in AsmBasedTaskDescriptor

It is not obvious why it will hang, a guess is that some lambda functions are being evaluated multiple times.

This changes it to add more print information to locate those lambda function