### PR TITLE
Fix cancel() implementation in ListanbleFutureUtil

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 2
       - uses: actions/setup-python@v2
         with:
-          python-version: '2.7.5'
+          python-version: '3.9.12'
           cache: 'pip'
       - uses: actions/setup-java@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.9.12'
+          python-version: '2.7.18'
       - uses: actions/setup-java@v2
         with:
           distribution: zulu

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           # Need to fetch 2 commits for the PR (base commit and head merge commit) so we can compute the diff
           fetch-depth: 2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '2.7.5'
+          cache: 'pip'
       - uses: actions/setup-java@v2
         with:
           distribution: zulu

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.9.12'
-          cache: 'pip'
       - uses: actions/setup-java@v2
         with:
           distribution: zulu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v5.1.12
+------
+* Fixed cancel() implementation in ListenableFutureUtil
+
+
 v5.1.11
 ------
 * Upgrade bytebuddy version so it can support JDK 17

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=5.1.11
+version=5.1.12
 group=com.linkedin.parseq
 org.gradle.parallel=true

--- a/subprojects/parseq-guava-interop/src/main/java/com/linkedin/parseq/guava/ListenableFutureUtil.java
+++ b/subprojects/parseq-guava-interop/src/main/java/com/linkedin/parseq/guava/ListenableFutureUtil.java
@@ -43,14 +43,14 @@ public class ListenableFutureUtil {
           public boolean cancel(Exception rootReason) {
             // <BaseTask>.cancel()'s result indicates whether cancel() successfully trigger state transition to "CANCELLED"
             // And we should only cancel GRPC future when the transition was conducted.
-            boolean baseStateTransitedByCallingCancel = super.cancel(rootReason);
-            if (baseStateTransitedByCallingCancel && !future.isCancelled()) {
+            boolean shouldCancelTask = super.cancel(rootReason);
+            if (shouldCancelTask && !future.isCancelled()) {
               boolean futureCancelResult = future.cancel(true);
               if (!futureCancelResult) {
-                LOGGER.error("Unexpected error: GRPC future was not cancelled but new attempt to cancel also failed.");
+                LOGGER.warn("Unexpected: GRPC future was not cancelled but new attempt to cancel also failed.");
               }
             }
-            return baseStateTransitedByCallingCancel;
+            return shouldCancelTask;
           }
 
           @Override


### PR DESCRIPTION
Previous implementation has two problems that fixed in this PR.

1. We now use best effort to cancel GRPC future and that shouldn't impact the return value of `cancelled()` that supposed to indicate base Task cancellation 
2. We should  only cancel GRPC future when base task state transition confirmed to happen.