### PR TITLE
Pin python version in the publish github action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,9 @@ jobs:
           distribution: zulu
           java-version: ${{ matrix.java }}
           # Do NOT use caching, since we want to ensure published artifacts are fresh
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '2.7.18'
       - run: ./.github/scripts/publish.sh
         env:
           JFROG_USER: ${{ secrets.JFROG_USER }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v5.1.13
+------
+* Pin python version for the "publish" github action 
+
 v5.1.12
 ------
 * Fixed cancel() implementation in ListenableFutureUtil

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=5.1.12
+version=5.1.13
 group=com.linkedin.parseq
 org.gradle.parallel=true


### PR DESCRIPTION
Have to pin the python version since new version doesn't work with node-gyp