### PR TITLE
run sendRequest in an executor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ target
 /.gradle
 .settings
 subprojects/parseq-lambda-names/bin/
+subprojects/parseq-tracevis/npm-debug.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v5.1.16
+------
+* Add the support of offloading sendRequest call to an executor
+
 v5.1.15
 ------
 * Fix stack overflow error in TaskDescriptor when lambda is used

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=5.1.15
+version=5.1.16
 group=com.linkedin.parseq
 org.gradle.parallel=true

--- a/subprojects/parseq-restli-client/src/main/java/com/linkedin/restli/client/DirectExecutor.java
+++ b/subprojects/parseq-restli-client/src/main/java/com/linkedin/restli/client/DirectExecutor.java
@@ -1,0 +1,21 @@
+package com.linkedin.restli.client;
+
+import java.util.concurrent.Executor;
+
+
+/**
+ * A simple executor implementation that executes the task immediately on the calling thread
+ */
+class DirectExecutor implements Executor {
+
+  private static final DirectExecutor INSTANCE = new DirectExecutor();
+
+  static DirectExecutor getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    command.run();
+  }
+}

--- a/subprojects/parseq-restli-client/src/main/java/com/linkedin/restli/client/ParSeqRestClient.java
+++ b/subprojects/parseq-restli-client/src/main/java/com/linkedin/restli/client/ParSeqRestClient.java
@@ -16,7 +16,6 @@
 
 package com.linkedin.restli.client;
 
-import com.google.common.util.concurrent.MoreExecutors;
 import com.linkedin.common.callback.Callback;
 import com.linkedin.parseq.Task;
 import com.linkedin.parseq.batching.Batch;
@@ -37,9 +36,6 @@ import com.linkedin.restli.client.metrics.Metrics;
 import com.linkedin.restli.common.OperationNameGenerator;
 import java.util.Optional;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.slf4j.Logger;
@@ -98,7 +94,7 @@ public class ParSeqRestClient extends BatchingStrategy<RequestGroup, RestRequest
     _requestConfigProvider = requestConfigProvider;
     _requestContextProvider = requestContextProvider;
     _d2RequestTimeoutEnabled = d2RequestTimeoutEnabled;
-    _executor = MoreExecutors.directExecutor();
+    _executor = DirectExecutor.getInstance();
   }
 
   /**
@@ -113,7 +109,7 @@ public class ParSeqRestClient extends BatchingStrategy<RequestGroup, RestRequest
     _requestConfigProvider = RequestConfigProvider.build(new ParSeqRestliClientConfigBuilder().build(), () -> Optional.empty());
     _requestContextProvider = request -> new RequestContext();
     _d2RequestTimeoutEnabled = false;
-    _executor = MoreExecutors.directExecutor();
+    _executor = DirectExecutor.getInstance();
   }
 
   /**
@@ -128,7 +124,7 @@ public class ParSeqRestClient extends BatchingStrategy<RequestGroup, RestRequest
     _requestConfigProvider = RequestConfigProvider.build(new ParSeqRestliClientConfigBuilder().build(), () -> Optional.empty());
     _requestContextProvider = request -> new RequestContext();
     _d2RequestTimeoutEnabled = false;
-    _executor = MoreExecutors.directExecutor();
+    _executor = DirectExecutor.getInstance();
   }
 
   @Override

--- a/subprojects/parseq-restli-client/src/main/java/com/linkedin/restli/client/ParSeqRestClient.java
+++ b/subprojects/parseq-restli-client/src/main/java/com/linkedin/restli/client/ParSeqRestClient.java
@@ -87,14 +87,7 @@ public class ParSeqRestClient extends BatchingStrategy<RequestGroup, RestRequest
 
   ParSeqRestClient(final Client client, final RequestConfigProvider requestConfigProvider,
       Function<Request<?>, RequestContext> requestContextProvider, final boolean d2RequestTimeoutEnabled) {
-    ArgumentUtil.requireNotNull(client, "client");
-    ArgumentUtil.requireNotNull(requestConfigProvider, "requestConfigProvider");
-    ArgumentUtil.requireNotNull(requestContextProvider, "requestContextProvider");
-    _client = client;
-    _requestConfigProvider = requestConfigProvider;
-    _requestContextProvider = requestContextProvider;
-    _d2RequestTimeoutEnabled = d2RequestTimeoutEnabled;
-    _executor = DirectExecutor.getInstance();
+    this(client, requestConfigProvider, requestContextProvider, d2RequestTimeoutEnabled, DirectExecutor.getInstance());
   }
 
   /**

--- a/subprojects/parseq-restli-client/src/main/java/com/linkedin/restli/client/ParSeqRestliClientBuilder.java
+++ b/subprojects/parseq-restli-client/src/main/java/com/linkedin/restli/client/ParSeqRestliClientBuilder.java
@@ -1,8 +1,10 @@
 package com.linkedin.restli.client;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Executor;
 import java.util.function.Function;
 
 import org.slf4j.Logger;
@@ -35,6 +37,7 @@ public class ParSeqRestliClientBuilder {
   private BatchingSupport _batchingSupport;
   private InboundRequestContextFinder _inboundRequestContextFinder;
   private Function<Request<?>, RequestContext> _requestContextProvider;
+  private Executor _executor = MoreExecutors.directExecutor();
 
   /**
    * This method may throw RuntimeException e.g. when there is a problem with configuration.
@@ -65,7 +68,7 @@ public class ParSeqRestliClientBuilder {
         request -> new RequestContext() :
         _requestContextProvider;
 
-    ParSeqRestClient parseqClient = new ParSeqRestClient(_client, configProvider, requestContextProvider, _d2RequestTimeoutEnabled);
+    ParSeqRestClient parseqClient = new ParSeqRestClient(_client, configProvider, requestContextProvider, _d2RequestTimeoutEnabled, _executor);
     if (_batchingSupport != null) {
       LOGGER.debug("Found batching support");
       _batchingSupport.registerStrategy(parseqClient);
@@ -158,6 +161,11 @@ public class ParSeqRestliClientBuilder {
    */
   public ParSeqRestliClientBuilder setD2RequestTimeoutEnabled(boolean enabled) {
     _d2RequestTimeoutEnabled = enabled;
+    return this;
+  }
+
+  public ParSeqRestliClientBuilder setExecutor(Executor executor) {
+    _executor = executor;
     return this;
   }
 }

--- a/subprojects/parseq-restli-client/src/main/java/com/linkedin/restli/client/ParSeqRestliClientBuilder.java
+++ b/subprojects/parseq-restli-client/src/main/java/com/linkedin/restli/client/ParSeqRestliClientBuilder.java
@@ -1,6 +1,5 @@
 package com.linkedin.restli.client;
 
-import com.google.common.util.concurrent.MoreExecutors;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -37,7 +36,7 @@ public class ParSeqRestliClientBuilder {
   private BatchingSupport _batchingSupport;
   private InboundRequestContextFinder _inboundRequestContextFinder;
   private Function<Request<?>, RequestContext> _requestContextProvider;
-  private Executor _executor = MoreExecutors.directExecutor();
+  private Executor _executor = DirectExecutor.getInstance();
 
   /**
    * This method may throw RuntimeException e.g. when there is a problem with configuration.

--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/FusionTask.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/FusionTask.java
@@ -99,11 +99,11 @@ class FusionTask<S, T> extends BaseTask<T> {
   }
 
   private void addRelationships(final FusionTraceContext traceContext) {
-    final ShallowTraceBuilder effectoveShallowTraceBuilder = getEffectiveShallowTraceBuilder(traceContext);
+    final ShallowTraceBuilder effectiveShallowTraceBuilder = getEffectiveShallowTraceBuilder(traceContext);
     TraceBuilder builder = getTraceBuilder();
-    builder.addRelationship(Relationship.PARENT_OF, traceContext.getParent().getShallowTraceBuilder(), effectoveShallowTraceBuilder);
+    builder.addRelationship(Relationship.PARENT_OF, traceContext.getParent().getShallowTraceBuilder(), effectiveShallowTraceBuilder);
     if (_predecessorShallowTraceBuilder != null) {
-      builder.addRelationship(Relationship.SUCCESSOR_OF, effectoveShallowTraceBuilder, _predecessorShallowTraceBuilder);
+      builder.addRelationship(Relationship.SUCCESSOR_OF, effectiveShallowTraceBuilder, _predecessorShallowTraceBuilder);
     }
   }
 


### PR DESCRIPTION
This PR adds the option to run sendRequest in a dedicated threadpool.

Although sendRequest is asynchronous, we found that it may still block the scheduling thread for extended amount of time in certain scenarios.

Here is one example we had in production:

![image](https://github.com/linkedin/parseq/assets/110351415/c6b64540-fab6-484e-8f9c-eaf44736cc9f)

With this change, we no longer have such blocking behavior in the scheduling thread.
