### PR TITLE
Release 5.1.18 with trace visualizer updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v5.1.18
+------
+* Minor UI updates to trace visualizer to refresh JavaScript dependencies.
+
 v5.1.17
 ------
 * Use dedicated executor service for lambda analysis

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=5.1.17
+version=5.1.18
 group=com.linkedin.parseq
 org.gradle.parallel=true


### PR DESCRIPTION
Release of UI changes from https://github.com/linkedin/parseq/pull/342.