### PR TITLE
Explicitly set default value to "UNFINISHED" for TraceBuilder's ResultType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v5.1.19
+------
+* Explicitly set default value for TraceBuilder's ResultType to UNFINISHED to prevent null argument when building the trace in TraceBuilder.
+
 v5.1.18
 ------
 * Minor UI updates to trace visualizer to refresh JavaScript dependencies.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=5.1.18
+version=5.1.19
 group=com.linkedin.parseq
 org.gradle.parallel=true

--- a/subprojects/parseq-lambda-names/src/main/java/com/linkedin/parseq/lambda/SourcePointer.java
+++ b/subprojects/parseq-lambda-names/src/main/java/com/linkedin/parseq/lambda/SourcePointer.java
@@ -22,7 +22,7 @@ class SourcePointer {
         .findFirst()
         .map(SourcePointer::sourcePointer);
     if (!ret.isPresent()) {
-      System.out.println("WARNING： ParSeq cannot generate lambda function SourcePointer， "
+      System.out.println("WARNING: ParSeq cannot generate lambda function SourcePointer."
           + "source stacktrace will be printed:");
       exception.printStackTrace();
     }

--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/trace/ShallowTraceBuilder.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/trace/ShallowTraceBuilder.java
@@ -38,7 +38,7 @@ public class ShallowTraceBuilder {
   private volatile String _name;
   private volatile boolean _hidden;
   private volatile String _value;
-  private volatile ResultType _resultType = ResultType.UNFINISHED
+  private volatile ResultType _resultType = ResultType.UNFINISHED;
   private volatile long _startNanos = -1;
   private volatile long _pendingNanos = -1;
   private volatile long _endNanos = -1;

--- a/subprojects/parseq/src/main/java/com/linkedin/parseq/trace/ShallowTraceBuilder.java
+++ b/subprojects/parseq/src/main/java/com/linkedin/parseq/trace/ShallowTraceBuilder.java
@@ -38,7 +38,7 @@ public class ShallowTraceBuilder {
   private volatile String _name;
   private volatile boolean _hidden;
   private volatile String _value;
-  private volatile ResultType _resultType;
+  private volatile ResultType _resultType = ResultType.UNFINISHED
   private volatile long _startNanos = -1;
   private volatile long _pendingNanos = -1;
   private volatile long _endNanos = -1;


### PR DESCRIPTION
# Summary

## Symptom
There has been a report that some race condition can cause `resultType` being referenced as required constructor argument from a builder (during trace build) before it is being set.

StackTrace is as below:
```
java.lang.NullPointerException: resultType must not be null"java.lang.NullPointerException: resultType must not be null
  at com.linkedin.parseq.internal.ArgumentUtil.requireNotNull(ArgumentUtil.java:28)
  at com.linkedin.parseq.trace.ShallowTraceImp.<init>(ShallowTraceImp.java:52)
  at com.linkedin.parseq.trace.ShallowTraceBuilder.build(ShallowTraceBuilder.java:304)
  at com.linkedin.parseq.trace.TraceBuilder.lambda$build$1(TraceBuilder.java:85)
  at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1133)
  at com.linkedin.parseq.trace.TraceBuilder.build(TraceBuilder.java:85)
  at com.linkedin.parseq.BaseTask.getTrace(BaseTask.java:292)
  at com.linkedin.parseq.trace.TraceUtil.getJsonTrace(TraceUtil.java:22)
  at com.linkedin.parseq.ParSeqUnitTestHelper.logTracingResults(ParSeqUnitTestHelper.java:346)
  at com.linkedin.parseq.ParSeqUnitTestHelper.runAndWait(ParSeqUnitTestHelper.java:172)
  at com.linkedin.parseq.ParSeqUnitTestHelper.runAndWait(ParSeqUnitTestHelper.java:147)
  at com.linkedin.parseq.AbstractBaseEngineTest.runAndWait(AbstractBaseEngineTest.java:59)

```

## Invesetigation
It is intermittent so it is rather hard to reproduce. By inspecting the code, it is also not clear when `setResultType` was be exempted from being called sometimes.

## Impact assessment
The issue should only impact trace and we don't get such report for years. Only two users ever reported and both claim to be intermittent. I think we can set a default value of "UNFINISHED" so the exception won't be thrown during the run time.  We therefore let the "bad" trace to be surfaced and investigated if the trace itself does not make sense.

## Details about code change
- Set an explicit default value of `ResultType.UNFINISHED`
- Also fix another location where invalid ascii character were used and cannot build on certain machine (e.g. my machine which uses CBL-Mariner distribution)

# Testing done
`./gradlew build` and `./gradlew test`