### PR TITLE
Fix bridging for get

### DIFF
--- a/subprojects/parseq-guava-interop/src/test/java/com/linkedin/parseq/guava/ListenableFutureUtilTest.java
+++ b/subprojects/parseq-guava-interop/src/test/java/com/linkedin/parseq/guava/ListenableFutureUtilTest.java
@@ -62,6 +62,13 @@ public class ListenableFutureUtilTest extends BaseEngineTest {
     Assert.assertTrue(task.isDone());
     Assert.assertTrue(task.isFailed());
     Assert.assertEquals(task.getError().getCause().getClass(), CancellationException.class);
+
+    listenableFuture = new ListenableFutureUtil.SettableFuture<>();
+    task = ListenableFutureUtil.fromListenableFuture(listenableFuture);
+
+    // Test get.
+    listenableFuture.set("Haha");
+    Assert.assertEquals(task.get(), "Haha");
   }
 
   @Test


### PR DESCRIPTION
We use the delegated promise of the BaseTask instead of creating another one to make sure that get also gets bridged correctly.