### PR TITLE
Fix flaky test testStaticWithSideEffectFullCompletion

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -22,4 +22,4 @@ if [ -z "$VERSION" ]; then
 fi
 
 # Run the actual build
-./gradlew -Prelease build
+./gradlew -Prelease build -is

--- a/subprojects/parseq/src/test/java/com/linkedin/parseq/AbstractTaskTest.java
+++ b/subprojects/parseq/src/test/java/com/linkedin/parseq/AbstractTaskTest.java
@@ -392,7 +392,6 @@ public abstract class AbstractTaskTest extends BaseEngineTest {
     Task<Void> sideEffect = Task.withSideEffect(() -> slowSideEffect);
 
     run(sideEffect);
-    assertFalse(sideEffect.isDone());
     sideEffect.await();
     assertTrue(sideEffect.isDone());
     assertNull(sideEffect.get());


### PR DESCRIPTION
Test failures in github action: https://github.com/linkedin/parseq/actions/runs/16303725941/job/46050223728 

The current test `testStaticWithSideEffectFullCompletion` assert that the task is not done immediately after invoking `run`:
```
    Task<Void> sideEffect = Task.withSideEffect(() -> slowSideEffect);
    run(sideEffect);
    assertFalse(sideEffect.isDone());
```
However, this may not be true in all environments and looks like in github action the task can be completed faster.
Removing the assertion to make the test stable in github action.